### PR TITLE
fix: allow extra config fields for Smithery compatibility

### DIFF
--- a/src/devplan_mcp/server.py
+++ b/src/devplan_mcp/server.py
@@ -1168,7 +1168,7 @@ async def get_template_resource(name: str) -> str:
 class ServerConfigSchema(BaseModel):
     """Configuration options for DevPlan MCP Server."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")
 
     default_template: str = Field(
         default="base",


### PR DESCRIPTION
## Summary
- Changed `ServerConfigSchema` from `extra='forbid'` to `extra='ignore'`
- Fixes "Configuration Error: Invalid configuration" on Smithery deployment
- Smithery may send additional fields that were being rejected

## Test plan
- [ ] Deploy to Smithery and verify scan completes without config error
- [ ] Verify tools are discoverable after successful scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)