### PR TITLE
fix: minimize __init__.py to match Smithery quickstart

### DIFF
--- a/src/devplan_mcp/__init__.py
+++ b/src/devplan_mcp/__init__.py
@@ -1,12 +1,2 @@
-"""
-DevPlan MCP Server - Generate development plans via Model Context Protocol.
-
-This package exposes the ClaudeCode-DevPlanBuilder functionality as MCP tools.
-"""
-
+# DevPlan MCP Server - Generate development plans via Model Context Protocol
 __version__ = "0.1.0"
-__author__ = "Mike Morris"
-
-from devplan_mcp.server import create_server
-
-__all__ = ["create_server"]


### PR DESCRIPTION
Removes eager imports that may conflict with Smithery's module loading.