### PR TITLE
fix: switch to container runtime with custom Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use a Python image with uv pre-installed
+FROM ghcr.io/astral-sh/uv:python3.12-alpine
+
+# Install the project into `/app`
+WORKDIR /app
+
+# Enable bytecode compilation
+ENV UV_COMPILE_BYTECODE=1
+
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
+
+# Copy project files
+COPY pyproject.toml .
+COPY src/ src/
+
+# Install dependencies
+RUN uv sync --no-dev
+
+# Place executables in the environment at the front of the path
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Reset the entrypoint, don't invoke `uv`
+ENTRYPOINT []
+
+# Run using smithery's start command with correct host
+CMD ["python", "-m", "smithery.cli.start", "--host", "0.0.0.0", "--port", "8081"]

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,1 +1,6 @@
-runtime: "python"
+runtime: "container"
+build:
+  dockerfile: "Dockerfile"
+  dockerBuildPath: "."
+startCommand:
+  type: "http"


### PR DESCRIPTION
## Summary
- Changed from `runtime: "python"` to `runtime: "container"` 
- Added custom Dockerfile that explicitly runs smithery.cli.start with `--host 0.0.0.0`
- The python runtime was giving 502 errors - possibly due to host binding issues

## Test plan
- [ ] Smithery should build and scan successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)