### PR TITLE
fix: use official Smithery dependency versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,8 @@ description = "MCP server for generating development plans"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp>=1.14.1",
-    "smithery>=0.2.4",
+    "mcp>=1.15.0",
+    "smithery>=0.4.2",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Update to smithery>=0.4.2 (was 0.2.4)
- Update to mcp>=1.15.0 (was 1.14.1)
- Matches official Smithery documentation requirements

## Test plan
- [ ] Merge and verify Smithery deployment succeeds without 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)