### PR TITLE
fix: simplify pyproject.toml to match cookbook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
-
 [project]
 name = "devplan-mcp"
 version = "0.1.0"
@@ -9,7 +5,5 @@ description = "MCP server for generating development plans"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "mcp>=1.1.0",
-    "uvicorn>=0.30.0",
-    "starlette>=0.37.0",
+    "mcp[cli]>=1.12.4",
 ]


### PR DESCRIPTION
Remove hatchling build system and use mcp[cli] like the working Smithery cookbook example.