### PR TITLE
fix: add SmitheryConfigMiddleware and configSchema for Smithery

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import os
 import uvicorn
 from mcp.server.fastmcp import FastMCP
 from starlette.middleware.cors import CORSMiddleware
+from middleware import SmitheryConfigMiddleware
 
 # Initialize MCP server
 mcp = FastMCP(name="DevPlan")
@@ -16,28 +17,40 @@ def hello(name: str) -> str:
 
 
 def main():
-    """Run the server in HTTP mode."""
-    print("DevPlan MCP Server starting...")
+    """Run the server based on TRANSPORT environment variable."""
+    transport_mode = os.getenv("TRANSPORT", "stdio")
 
-    # Setup Starlette app with CORS for cross-origin requests
-    app = mcp.streamable_http_app()
+    if transport_mode == "http":
+        # HTTP mode for Smithery deployment
+        print("DevPlan MCP Server starting in HTTP mode...")
 
-    # Add CORS middleware for browser-based clients
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
-        allow_methods=["GET", "POST", "OPTIONS"],
-        allow_headers=["*"],
-        expose_headers=["mcp-session-id", "mcp-protocol-version"],
-        max_age=86400,
-    )
+        # Setup Starlette app with CORS for cross-origin requests
+        app = mcp.streamable_http_app()
 
-    # Get port from environment variable (Smithery sets to 8081)
-    port = int(os.environ.get("PORT", 8080))
-    print(f"Listening on port {port}")
+        # Add CORS middleware for browser-based clients
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_credentials=True,
+            allow_methods=["GET", "POST", "OPTIONS"],
+            allow_headers=["*"],
+            expose_headers=["mcp-session-id", "mcp-protocol-version"],
+            max_age=86400,
+        )
 
-    uvicorn.run(app, host="0.0.0.0", port=port, log_level="debug")
+        # Apply Smithery config middleware for session config extraction
+        app = SmitheryConfigMiddleware(app)
+
+        # Get port from environment variable (Smithery sets PORT)
+        port = int(os.environ.get("PORT", 8080))
+        print(f"Listening on port {port}")
+
+        uvicorn.run(app, host="0.0.0.0", port=port, log_level="debug")
+
+    else:
+        # STDIO mode for local development
+        print("DevPlan MCP Server starting in stdio mode...")
+        mcp.run()
 
 
 if __name__ == "__main__":

--- a/middleware.py
+++ b/middleware.py
@@ -1,0 +1,31 @@
+"""Smithery middleware for config extraction from URL parameters."""
+
+import json
+import base64
+from urllib.parse import parse_qs, unquote
+
+
+class SmitheryConfigMiddleware:
+    """Middleware to extract Smithery config from URL query parameters."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope.get('type') == 'http':
+            query = scope.get('query_string', b'').decode()
+
+            if 'config=' in query:
+                try:
+                    config_b64 = unquote(parse_qs(query)['config'][0])
+                    config = json.loads(base64.b64decode(config_b64))
+
+                    # Inject full config into request scope for per-request access
+                    scope['smithery_config'] = config
+                except Exception as e:
+                    print(f"SmitheryConfigMiddleware: Error parsing config: {e}")
+                    scope['smithery_config'] = {}
+            else:
+                scope['smithery_config'] = {}
+
+        await self.app(scope, receive, send)

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -4,3 +4,7 @@ build:
   dockerBuildPath: "."
 startCommand:
   type: "http"
+  configSchema:
+    type: "object"
+    properties: {}
+    required: []


### PR DESCRIPTION
## Summary
- Add `middleware.py` with `SmitheryConfigMiddleware` to extract config from URL query params
- Update `main.py` to check `TRANSPORT` env var and wrap the app with the middleware
- Add `configSchema` to `smithery.yaml` as required by Smithery proxy

This matches the structure of the working cookbook example (`@smithery-ai/cookbook-py-custom-container`).

## Test plan
- [ ] Merge PR to trigger Smithery rebuild
- [ ] Verify `.well-known/mcp-config` still responds
- [ ] Verify POST `/mcp` returns 200 instead of 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)