### PR TITLE
fix: add issues write permission to workflow

### DIFF
--- a/.github/workflows/reference-repo-updated.yml
+++ b/.github/workflows/reference-repo-updated.yml
@@ -12,6 +12,9 @@ on:
         description: 'Commit message (for testing)'
         default: 'Manual test trigger'
 
+permissions:
+  issues: write
+
 jobs:
   create-issue:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The workflow needs write permission to create issues.