### PR TITLE
chore: ignore DevPlan planning artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,12 @@ server.json
 
 # Build
 dist/
+
+# DevPlan planning artifacts
+PROJECT_BRIEF.md
+DEVELOPMENT_PLAN.md
+CLAUDE.md
+.claude/
+
+# Generated types
+worker-configuration.d.ts


### PR DESCRIPTION
## Summary

Add planning artifacts to .gitignore to keep them local:

- `PROJECT_BRIEF.md` - Project requirements
- `DEVELOPMENT_PLAN.md` - Development plan
- `CLAUDE.md` - Project rules for Claude
- `.claude/` - Agent definitions
- `worker-configuration.d.ts` - Generated types

These files are useful for local development with DevPlan but shouldn't be committed to the repository.

🤖 Generated with [Claude Code](https://claude.ai/code)