### PR TITLE
fix: reduce DO bloat with aggressive cleanup and bot blocking

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,7 +7,7 @@ compatibility_flags = ["nodejs_compat"]
 [vars]
 AUTH_ENABLED = "false"  # Set to "true" to require API keys
 FREE_TIER_LIMIT = "100"  # Requests per month for free tier
-SESSION_INACTIVITY_TTL_DAYS = "7"  # Days of inactivity before session cleanup
+SESSION_INACTIVITY_TTL_DAYS = "1"  # Days of inactivity before session cleanup
 SESSION_ABSOLUTE_TTL_DAYS = "30"   # Maximum session age in days
 CLEANUP_CHECK_HOURS = "6"          # Hours between cleanup alarm checks
 


### PR DESCRIPTION
## Summary

Addresses Cloudflare quota warnings (90% of daily DO limit) by:

1. **Aggressive cleanup** - Reduce inactivity TTL from 7 days to 1 day
2. **Bot blocking** - Prevent non-MCP clients from creating DOs

## Changes

### Option 1: Faster cleanup
- `SESSION_INACTIVITY_TTL_DAYS`: 7 → 1

### Option 3: Block non-MCP clients
- Block bot User-Agents: `bot|crawler|spider|scraper|curl|wget|python-requests|go-http|java/|php/|ruby`
- `/sse` requires `Accept: text/event-stream`
- `/mcp` POST requires `Content-Type: application/json` and `Accept: application/json`

## Root cause

Every request without a session ID creates a new Durable Object:
```javascript
const sessionId = url.searchParams.get("sessionId") || namespace.newUniqueId().toString();
const agent = await getAgentByName(namespace, `sse:${sessionId}`, ...);
```

Bots/crawlers hitting `/sse` were creating DOs that accumulated.

## Test plan

- [x] TypeScript compiles
- [x] All 53 tests pass
- [x] Deployed to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)