### PR TITLE
feat(dashboard): add custom domain and Cloudflare Zone Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ flowchart LR
 ## Install
 
 ```bash
-claude mcp add devplan --transport sse https://devplan-mcp-server.mike-c63.workers.dev/sse
+claude mcp add devplan --transport sse https://devplanmcp.store/sse
 ```
 
 Or add to `~/.claude/mcp.json`:
@@ -63,7 +63,7 @@ Or add to `~/.claude/mcp.json`:
   "mcpServers": {
     "devplan": {
       "type": "sse",
-      "url": "https://devplan-mcp-server.mike-c63.workers.dev/sse"
+      "url": "https://devplanmcp.store/sse"
     }
   }
 }
@@ -266,9 +266,9 @@ graph TB
 
 DevPlan includes a public dashboard for viewing aggregate usage statistics:
 
-**Dashboard URL**: [devplan-mcp-server.mike-c63.workers.dev/dashboard](https://devplan-mcp-server.mike-c63.workers.dev/dashboard)
+**Dashboard URL**: [devplanmcp.store/dashboard](https://devplanmcp.store/dashboard)
 
-**API Endpoint**: [devplan-mcp-server.mike-c63.workers.dev/dashboard/api/stats](https://devplan-mcp-server.mike-c63.workers.dev/dashboard/api/stats)
+**API Endpoint**: [devplanmcp.store/dashboard/api/stats](https://devplanmcp.store/dashboard/api/stats)
 
 The dashboard shows:
 - **Summary cards**: Total sessions, total tool calls, countries reached

--- a/src/cloudflare-analytics.ts
+++ b/src/cloudflare-analytics.ts
@@ -1,0 +1,280 @@
+/**
+ * Cloudflare Analytics API Module
+ *
+ * Fetches analytics data from Cloudflare's GraphQL Analytics API.
+ * Uses Zone Analytics for real unique visitor counts (requires custom domain).
+ * This is a zero-write solution - Cloudflare already collects the data.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface CloudflareAnalyticsEnv {
+	CF_ANALYTICS_TOKEN: string;
+	CF_ACCOUNT_ID: string;
+	CF_ZONE_ID: string;
+}
+
+export interface DailyVisitors {
+	date: string;
+	uniqueVisitors: number;
+	requests: number;
+}
+
+export interface CountryData {
+	countryCode: string;
+	countryName: string;
+	requests: number;
+	uniqueVisitors: number;
+}
+
+export interface AnalyticsData {
+	dailyData: DailyVisitors[];
+	countryData: CountryData[];
+	totals: {
+		uniqueVisitors: number;
+		requests: number;
+		countries: number;
+	};
+	lastUpdated: string;
+}
+
+// Cloudflare Zone Analytics GraphQL response types
+interface ZoneHttpRequest1dGroup {
+	dimensions: {
+		date: string;
+	};
+	uniq: {
+		uniques: number;
+	};
+	sum: {
+		requests: number;
+		countryMap: Array<{
+			clientCountryName: string;
+			requests: number;
+		}>;
+	};
+}
+
+interface CFZoneGraphQLResponse {
+	data?: {
+		viewer: {
+			zones: Array<{
+				httpRequests1dGroups: ZoneHttpRequest1dGroup[];
+			}>;
+		};
+	};
+	errors?: Array<{ message: string; path?: string[] }>;
+}
+
+// ============================================================================
+// Country Code Mapping
+// ============================================================================
+
+const COUNTRY_NAME_TO_CODE: Record<string, string> = {
+	"United States": "US",
+	"China": "CN",
+	"Japan": "JP",
+	"Germany": "DE",
+	"United Kingdom": "GB",
+	"France": "FR",
+	"India": "IN",
+	"Italy": "IT",
+	"Brazil": "BR",
+	"Canada": "CA",
+	"Russia": "RU",
+	"South Korea": "KR",
+	"Australia": "AU",
+	"Spain": "ES",
+	"Mexico": "MX",
+	"Indonesia": "ID",
+	"Netherlands": "NL",
+	"Saudi Arabia": "SA",
+	"Turkey": "TR",
+	"Switzerland": "CH",
+	"Poland": "PL",
+	"Thailand": "TH",
+	"Sweden": "SE",
+	"Belgium": "BE",
+	"Argentina": "AR",
+	"Norway": "NO",
+	"Austria": "AT",
+	"United Arab Emirates": "AE",
+	"Israel": "IL",
+	"Singapore": "SG",
+	"Hong Kong": "HK",
+	"Denmark": "DK",
+	"Finland": "FI",
+	"New Zealand": "NZ",
+	"Ireland": "IE",
+	"Portugal": "PT",
+	"Czechia": "CZ",
+	"Romania": "RO",
+	"Vietnam": "VN",
+	"Philippines": "PH",
+	"Malaysia": "MY",
+	"Colombia": "CO",
+	"Chile": "CL",
+	"South Africa": "ZA",
+	"Ukraine": "UA",
+	"Pakistan": "PK",
+	"Egypt": "EG",
+	"Nigeria": "NG",
+	"Bangladesh": "BD",
+	"Peru": "PE",
+	"Taiwan": "TW",
+	"Hong Kong SAR China": "HK",
+	"Korea": "KR",
+	"Republic of Korea": "KR",
+};
+
+function getCountryCode(name: string): string {
+	return COUNTRY_NAME_TO_CODE[name] || name.slice(0, 2).toUpperCase();
+}
+
+// ============================================================================
+// Analytics Fetching
+// ============================================================================
+
+/**
+ * Fetch analytics data from Cloudflare's GraphQL API.
+ * Uses Zone Analytics for real unique visitor counts.
+ */
+export async function fetchCloudflareAnalytics(env: CloudflareAnalyticsEnv): Promise<AnalyticsData> {
+	// Check if credentials are configured
+	if (!env.CF_ANALYTICS_TOKEN || !env.CF_ZONE_ID) {
+		return getEmptyAnalytics("Analytics not configured - missing CF_ANALYTICS_TOKEN or CF_ZONE_ID");
+	}
+
+	// Calculate date range (last 30 days)
+	const endDate = new Date();
+	const startDate = new Date();
+	startDate.setDate(startDate.getDate() - 30);
+
+	const formatDate = (d: Date) => d.toISOString().split("T")[0];
+
+	// Zone Analytics query - has real unique visitors
+	const query = `
+		query GetZoneAnalytics($zoneTag: string!, $startDate: Date!, $endDate: Date!) {
+			viewer {
+				zones(filter: { zoneTag: $zoneTag }) {
+					httpRequests1dGroups(
+						limit: 31
+						filter: { date_geq: $startDate, date_leq: $endDate }
+						orderBy: [date_ASC]
+					) {
+						dimensions {
+							date
+						}
+						uniq {
+							uniques
+						}
+						sum {
+							requests
+							countryMap {
+								clientCountryName
+								requests
+							}
+						}
+					}
+				}
+			}
+		}
+	`;
+
+	const variables = {
+		zoneTag: env.CF_ZONE_ID,
+		startDate: formatDate(startDate),
+		endDate: formatDate(endDate),
+	};
+
+	try {
+		const response = await fetch("https://api.cloudflare.com/client/v4/graphql", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${env.CF_ANALYTICS_TOKEN}`,
+			},
+			body: JSON.stringify({ query, variables }),
+		});
+
+		if (!response.ok) {
+			console.error(`Cloudflare API error: ${response.status} ${response.statusText}`);
+			return getEmptyAnalytics(`API error: ${response.status}`);
+		}
+
+		const result = (await response.json()) as CFZoneGraphQLResponse;
+
+		if (result.errors && result.errors.length > 0) {
+			console.error("Cloudflare GraphQL errors:", result.errors);
+			return getEmptyAnalytics(result.errors[0].message);
+		}
+
+		const groups = result.data?.viewer?.zones?.[0]?.httpRequests1dGroups;
+		if (!groups || groups.length === 0) {
+			return getEmptyAnalytics("No data returned - zone may not have traffic yet");
+		}
+
+		// Process daily data with REAL unique visitors
+		const dailyData: DailyVisitors[] = groups.map((g) => ({
+			date: g.dimensions.date,
+			uniqueVisitors: g.uniq.uniques, // REAL unique visitors from Cloudflare
+			requests: g.sum.requests,
+		}));
+
+		// Aggregate country data across all days
+		const countryAggregates = new Map<string, { requests: number; name: string }>();
+		for (const group of groups) {
+			for (const country of group.sum.countryMap) {
+				const existing = countryAggregates.get(country.clientCountryName) || {
+					requests: 0,
+					name: country.clientCountryName,
+				};
+				existing.requests += country.requests;
+				countryAggregates.set(country.clientCountryName, existing);
+			}
+		}
+
+		// Convert to sorted array (top 20 countries)
+		const countryData: CountryData[] = Array.from(countryAggregates.entries())
+			.map(([name, data]) => ({
+				countryCode: getCountryCode(name),
+				countryName: name,
+				requests: data.requests,
+				uniqueVisitors: 0, // Per-country uniques not available in this query
+			}))
+			.sort((a, b) => b.requests - a.requests)
+			.slice(0, 20);
+
+		// Calculate totals
+		const totals = {
+			uniqueVisitors: dailyData.reduce((sum, d) => sum + d.uniqueVisitors, 0),
+			requests: dailyData.reduce((sum, d) => sum + d.requests, 0),
+			countries: countryData.length,
+		};
+
+		return {
+			dailyData,
+			countryData,
+			totals,
+			lastUpdated: new Date().toISOString(),
+		};
+	} catch (error) {
+		console.error("Failed to fetch Cloudflare analytics:", error);
+		return getEmptyAnalytics(error instanceof Error ? error.message : "Unknown error");
+	}
+}
+
+function getEmptyAnalytics(reason: string): AnalyticsData {
+	return {
+		dailyData: [],
+		countryData: [],
+		totals: {
+			uniqueVisitors: 0,
+			requests: 0,
+			countries: 0,
+		},
+		lastUpdated: `Error: ${reason}`,
+	};
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -2,26 +2,21 @@
  * Dashboard Module
  *
  * Provides HTTP handlers for the usage dashboard UI and API endpoints.
+ * Uses Cloudflare Zone Analytics for real unique visitor counts.
  */
 
-import { fetchDashboardData, type AnalyticsTotals, type DailyStats, type CountryStats } from "./session-tracking";
+import { fetchCloudflareAnalytics, type CloudflareAnalyticsEnv } from "./cloudflare-analytics";
 
 // ============================================================================
 // Types
 // ============================================================================
 
-interface DashboardEnv {
+interface DashboardEnv extends CloudflareAnalyticsEnv {
 	DEVPLAN_KV: KVNamespace;
 }
 
-interface DashboardAPIResponse {
-	totals: AnalyticsTotals;
-	recentDays: DailyStats[];
-	topCountries: CountryStats[];
-}
-
 // ============================================================================
-// Country Code to Name Mapping (top 50 countries)
+// Country Code to Name Mapping
 // ============================================================================
 
 const COUNTRY_NAMES: Record<string, string> = {
@@ -75,6 +70,7 @@ const COUNTRY_NAMES: Record<string, string> = {
 	NG: "Nigeria",
 	BD: "Bangladesh",
 	PE: "Peru",
+	TW: "Taiwan",
 };
 
 function getCountryName(code: string): string {
@@ -85,23 +81,14 @@ function getCountryName(code: string): string {
 // API Handler
 // ============================================================================
 
-/**
- * Handle /dashboard/api/stats requests.
- * Returns JSON with analytics data.
- */
 export async function handleDashboardAPI(env: DashboardEnv): Promise<Response> {
 	try {
-		const data = await fetchDashboardData(env.DEVPLAN_KV);
-		const response: DashboardAPIResponse = {
-			totals: data.totals,
-			recentDays: data.recentDays,
-			topCountries: data.topCountries,
-		};
-		return new Response(JSON.stringify(response, null, 2), {
+		const data = await fetchCloudflareAnalytics(env);
+		return new Response(JSON.stringify(data, null, 2), {
 			status: 200,
 			headers: {
 				"Content-Type": "application/json",
-				"Cache-Control": "public, max-age=60", // Cache for 1 minute
+				"Cache-Control": "public, max-age=300",
 			},
 		});
 	} catch (error) {
@@ -116,32 +103,27 @@ export async function handleDashboardAPI(env: DashboardEnv): Promise<Response> {
 // Dashboard UI Handler
 // ============================================================================
 
-/**
- * Handle /dashboard requests.
- * Returns HTML page with usage dashboard.
- */
 export async function handleDashboard(request: Request, env: DashboardEnv): Promise<Response> {
-	// Fetch data for initial render
-	const data = await fetchDashboardData(env.DEVPLAN_KV);
+	const data = await fetchCloudflareAnalytics(env);
 
-	// Generate chart data JSON
-	const chartLabels = data.recentDays.map((d) => d.date.slice(5)); // MM-DD format
-	const chartSessions = data.recentDays.map((d) => d.sessions);
-	const chartToolCalls = data.recentDays.map((d) => d.toolCalls);
+	const chartLabels = data.dailyData.map((d) => d.date.slice(5));
+	const chartVisitors = data.dailyData.map((d) => d.uniqueVisitors);
+	const chartRequests = data.dailyData.map((d) => d.requests);
 
-	// Generate country table rows
-	const countryRows = data.topCountries
+	const countryRows = data.countryData
 		.map(
 			(c, i) => `
         <tr class="border-b border-gray-700">
           <td class="py-2 px-3">${i + 1}</td>
-          <td class="py-2 px-3">${getCountryName(c.countryCode)}</td>
-          <td class="py-2 px-3 text-right">${c.sessions.toLocaleString()}</td>
-          <td class="py-2 px-3 text-right">${c.toolCalls.toLocaleString()}</td>
+          <td class="py-2 px-3">${c.countryName || getCountryName(c.countryCode)}</td>
+          <td class="py-2 px-3 text-right">${c.requests.toLocaleString()}</td>
         </tr>
       `
 		)
 		.join("");
+
+	const isConfigured = !data.lastUpdated.startsWith("Error:");
+	const errorMessage = !isConfigured ? data.lastUpdated.replace("Error: ", "") : "";
 
 	const html = `<!DOCTYPE html>
 <html lang="en">
@@ -158,33 +140,47 @@ export async function handleDashboard(request: Request, env: DashboardEnv): Prom
 </head>
 <body class="min-h-screen text-gray-100 p-6">
   <div class="max-w-6xl mx-auto">
-    <!-- Header -->
     <header class="mb-8">
       <h1 class="text-3xl font-bold text-white mb-2">DevPlan MCP Server</h1>
       <p class="text-gray-400">Usage Dashboard</p>
     </header>
 
+    ${
+		!isConfigured
+			? `
+    <div class="card rounded-lg p-6 mb-8 border border-yellow-600">
+      <h2 class="text-xl font-semibold text-yellow-400 mb-2">Analytics Error</h2>
+      <p class="text-gray-300">${errorMessage}</p>
+      <p class="text-gray-400 mt-4 text-sm">
+        Make sure CF_ANALYTICS_TOKEN and CF_ZONE_ID secrets are set, and the token has Zone Analytics:Read permission.
+      </p>
+    </div>
+    `
+			: ""
+	}
+
     <!-- Summary Cards -->
     <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
       <div class="card rounded-lg p-6">
-        <div class="text-gray-400 text-sm mb-1">Total Sessions</div>
-        <div class="text-3xl font-bold text-white">${data.totals.totalSessions.toLocaleString()}</div>
+        <div class="text-gray-400 text-sm mb-1">Unique Visitors (30 days)</div>
+        <div class="text-3xl font-bold text-white">${data.totals.uniqueVisitors.toLocaleString()}</div>
+        <div class="text-xs text-gray-500 mt-1">Real data from Cloudflare</div>
       </div>
       <div class="card rounded-lg p-6">
-        <div class="text-gray-400 text-sm mb-1">Total Tool Calls</div>
-        <div class="text-3xl font-bold text-white">${data.totals.totalToolCalls.toLocaleString()}</div>
+        <div class="text-gray-400 text-sm mb-1">Total Requests (30 days)</div>
+        <div class="text-3xl font-bold text-white">${data.totals.requests.toLocaleString()}</div>
       </div>
       <div class="card rounded-lg p-6">
-        <div class="text-gray-400 text-sm mb-1">Countries Reached</div>
-        <div class="text-3xl font-bold text-white">${data.topCountries.length}</div>
+        <div class="text-gray-400 text-sm mb-1">Countries</div>
+        <div class="text-3xl font-bold text-white">${data.totals.countries}</div>
       </div>
     </div>
 
     <!-- Chart -->
     <div class="card rounded-lg p-6 mb-8">
-      <h2 class="text-xl font-semibold text-white mb-4">Sessions Over Last 30 Days</h2>
+      <h2 class="text-xl font-semibold text-white mb-4">Daily Traffic</h2>
       <div style="height: 300px;">
-        <canvas id="sessionsChart"></canvas>
+        <canvas id="trafficChart"></canvas>
       </div>
     </div>
 
@@ -192,15 +188,14 @@ export async function handleDashboard(request: Request, env: DashboardEnv): Prom
     <div class="card rounded-lg p-6">
       <h2 class="text-xl font-semibold text-white mb-4">Top Countries</h2>
       ${
-			data.topCountries.length > 0
+			data.countryData.length > 0
 				? `
       <table class="w-full text-sm">
         <thead>
           <tr class="text-gray-400 text-left border-b border-gray-700">
             <th class="py-2 px-3">#</th>
             <th class="py-2 px-3">Country</th>
-            <th class="py-2 px-3 text-right">Sessions</th>
-            <th class="py-2 px-3 text-right">Tool Calls</th>
+            <th class="py-2 px-3 text-right">Requests</th>
           </tr>
         </thead>
         <tbody>
@@ -208,13 +203,13 @@ export async function handleDashboard(request: Request, env: DashboardEnv): Prom
         </tbody>
       </table>
       `
-				: `<p class="text-gray-400">No geographic data available yet.</p>`
+				: `<p class="text-gray-400">No traffic data yet. Visit devplanmcp.store to start collecting analytics.</p>`
 		}
     </div>
 
-    <!-- Footer -->
     <footer class="mt-8 text-center text-gray-500 text-sm">
-      <p>Last updated: ${data.totals.lastUpdated || "Never"}</p>
+      <p>Last updated: ${isConfigured ? new Date(data.lastUpdated).toLocaleString() : "N/A"}</p>
+      <p class="mt-1 text-xs">Data from Cloudflare Zone Analytics</p>
       <p class="mt-2">
         <a href="/" class="text-blue-400 hover:text-blue-300">API Status</a>
         &middot;
@@ -224,37 +219,49 @@ export async function handleDashboard(request: Request, env: DashboardEnv): Prom
   </div>
 
   <script>
-    // Chart.js configuration
-    const ctx = document.getElementById('sessionsChart').getContext('2d');
+    const ctx = document.getElementById('trafficChart').getContext('2d');
     new Chart(ctx, {
       type: 'line',
       data: {
         labels: ${JSON.stringify(chartLabels)},
         datasets: [
           {
-            label: 'Sessions',
-            data: ${JSON.stringify(chartSessions)},
+            label: 'Unique Visitors',
+            data: ${JSON.stringify(chartVisitors)},
             borderColor: 'rgb(59, 130, 246)',
             backgroundColor: 'rgba(59, 130, 246, 0.1)',
             fill: true,
             tension: 0.3,
+            yAxisID: 'y',
           },
           {
-            label: 'Tool Calls',
-            data: ${JSON.stringify(chartToolCalls)},
+            label: 'Requests',
+            data: ${JSON.stringify(chartRequests)},
             borderColor: 'rgb(16, 185, 129)',
             backgroundColor: 'rgba(16, 185, 129, 0.1)',
             fill: true,
             tension: 0.3,
+            yAxisID: 'y1',
           }
         ]
       },
       options: {
         responsive: true,
         maintainAspectRatio: false,
+        interaction: {
+          mode: 'index',
+          intersect: false,
+        },
         plugins: {
           legend: {
             labels: { color: '#9ca3af' }
+          },
+          tooltip: {
+            callbacks: {
+              label: function(context) {
+                return context.dataset.label + ': ' + context.parsed.y.toLocaleString();
+              }
+            }
           }
         },
         scales: {
@@ -263,9 +270,36 @@ export async function handleDashboard(request: Request, env: DashboardEnv): Prom
             grid: { color: '#374151' }
           },
           y: {
+            type: 'linear',
+            display: true,
+            position: 'left',
             beginAtZero: true,
-            ticks: { color: '#9ca3af' },
+            title: {
+              display: true,
+              text: 'Unique Visitors',
+              color: '#9ca3af'
+            },
+            ticks: {
+              color: '#9ca3af',
+              callback: function(value) { return value.toLocaleString(); }
+            },
             grid: { color: '#374151' }
+          },
+          y1: {
+            type: 'linear',
+            display: true,
+            position: 'right',
+            beginAtZero: true,
+            title: {
+              display: true,
+              text: 'Requests',
+              color: '#9ca3af'
+            },
+            ticks: {
+              color: '#9ca3af',
+              callback: function(value) { return value.toLocaleString(); }
+            },
+            grid: { drawOnChartArea: false }
           }
         }
       }
@@ -278,7 +312,7 @@ export async function handleDashboard(request: Request, env: DashboardEnv): Prom
 		status: 200,
 		headers: {
 			"Content-Type": "text/html; charset=utf-8",
-			"Cache-Control": "public, max-age=60", // Cache for 1 minute
+			"Cache-Control": "public, max-age=300",
 		},
 	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,10 @@ interface Env {
 	CLEANUP_CHECK_HOURS: string;
 	DEVPLAN_KV: KVNamespace;
 	MCP_OBJECT: DurableObjectNamespace;
+	// Cloudflare Analytics API (optional - for dashboard)
+	CF_ANALYTICS_TOKEN: string;
+	CF_ACCOUNT_ID: string;
+	CF_ZONE_ID: string;
 }
 
 export class DevPlanMCP extends McpAgent {
@@ -1840,6 +1844,12 @@ ${histogram || "| (no data) | |"}
 export default {
 	async fetch(request: Request, env: Env, ctx: ExecutionContext) {
 		const url = new URL(request.url);
+
+		// Redirect workers.dev to custom domain for consistent analytics
+		if (url.hostname.endsWith(".workers.dev")) {
+			const newUrl = new URL(url.pathname + url.search, "https://devplanmcp.store");
+			return Response.redirect(newUrl.toString(), 301);
+		}
 
 		// Health check endpoint - no auth required
 		if (url.pathname === "/" || url.pathname === "/health") {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,6 +2,12 @@ name = "devplan-mcp-server"
 main = "src/index.ts"
 compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
+workers_dev = true  # Keep workers.dev subdomain active
+
+# Custom domain
+routes = [
+  { pattern = "devplanmcp.store/*", zone_name = "devplanmcp.store" }
+]
 
 # Observability - logs errors and console output
 # Free tier: 10M log messages/month, 7-day retention
@@ -42,3 +48,11 @@ deleted_classes = ["DevPlanMCP"]
 [[migrations]]
 tag = "v3"
 new_sqlite_classes = ["DevPlanMCP"]
+
+# =============================================================================
+# Secrets (add via: wrangler secret put <NAME>)
+# =============================================================================
+# CF_ANALYTICS_TOKEN - Cloudflare API token with "Zone Analytics:Read" permission
+#                      Create at: https://dash.cloudflare.com/profile/api-tokens
+# CF_ZONE_ID         - Zone ID for devplanmcp.store
+# CF_ACCOUNT_ID      - Account ID (optional, for Workers analytics fallback)


### PR DESCRIPTION
## Summary
- Add devplanmcp.store custom domain with route config
- Implement Zone Analytics for real unique visitor counts (not fake estimates)
- Redirect workers.dev to devplanmcp.store for consistent analytics
- Update README with new domain URLs

## Changes
- `src/cloudflare-analytics.ts` - New module for Cloudflare Zone Analytics API
- `src/dashboard.ts` - Updated to show real unique visitors
- `src/index.ts` - Added redirect from workers.dev to devplanmcp.store
- `wrangler.toml` - Added custom domain route config
- `README.md` - Updated install URLs to use devplanmcp.store

## Test plan
- [ ] Visit https://devplanmcp.store/dashboard - should show analytics
- [ ] Visit https://devplan-mcp-server.mike-c63.workers.dev/ - should 301 redirect to devplanmcp.store
- [ ] MCP tools still work via new domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)