### PR TITLE
feat: separate MCP traffic to mcp.devplanmcp.store subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ flowchart LR
 ## Install
 
 ```bash
-claude mcp add devplan --transport sse https://devplanmcp.store/sse
+claude mcp add devplan --transport sse https://mcp.devplanmcp.store/sse
 ```
 
 Or add to `~/.claude/mcp.json`:
@@ -63,7 +63,7 @@ Or add to `~/.claude/mcp.json`:
   "mcpServers": {
     "devplan": {
       "type": "sse",
-      "url": "https://devplanmcp.store/sse"
+      "url": "https://mcp.devplanmcp.store/sse"
     }
   }
 }

--- a/src/cloudflare-analytics.ts
+++ b/src/cloudflare-analytics.ts
@@ -154,14 +154,18 @@ export async function fetchCloudflareAnalytics(env: CloudflareAnalyticsEnv): Pro
 
 	const formatDate = (d: Date) => d.toISOString().split("T")[0];
 
-	// Zone Analytics query - has real unique visitors
+	// Zone Analytics query - filter to MCP subdomain only for accurate user counts
 	const query = `
-		query GetZoneAnalytics($zoneTag: string!, $startDate: Date!, $endDate: Date!) {
+		query GetZoneAnalytics($zoneTag: string!, $startDate: Date!, $endDate: Date!, $hostname: string!) {
 			viewer {
 				zones(filter: { zoneTag: $zoneTag }) {
 					httpRequests1dGroups(
 						limit: 31
-						filter: { date_geq: $startDate, date_leq: $endDate }
+						filter: {
+							date_geq: $startDate,
+							date_leq: $endDate,
+							clientRequestHTTPHost: $hostname
+						}
 						orderBy: [date_ASC]
 					) {
 						dimensions {
@@ -187,6 +191,7 @@ export async function fetchCloudflareAnalytics(env: CloudflareAnalyticsEnv): Pro
 		zoneTag: env.CF_ZONE_ID,
 		startDate: formatDate(startDate),
 		endDate: formatDate(endDate),
+		hostname: "mcp.devplanmcp.store",
 	};
 
 	try {

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -41,13 +41,13 @@ export function handleLanding(): Response {
     <!-- Install -->
     <section class="mb-12">
       <h2 class="text-2xl font-bold text-white mb-4">Install</h2>
-      <pre class="text-green-400"><code>claude mcp add devplan --transport sse https://devplanmcp.store/sse</code></pre>
+      <pre class="text-green-400"><code>claude mcp add devplan --transport sse https://mcp.devplanmcp.store/sse</code></pre>
       <p class="text-gray-400 mt-4">Or add to <code>~/.claude/mcp.json</code>:</p>
       <pre class="mt-2"><code class="text-gray-300">{
   "mcpServers": {
     "devplan": {
       "type": "sse",
-      "url": "https://devplanmcp.store/sse"
+      "url": "https://mcp.devplanmcp.store/sse"
     }
   }
 }</code></pre>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,9 +4,10 @@ compatibility_date = "2024-12-01"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = true  # Keep workers.dev subdomain active
 
-# Custom domain
+# Custom domains
 routes = [
-  { pattern = "devplanmcp.store/*", zone_name = "devplanmcp.store" }
+  { pattern = "devplanmcp.store/*", zone_name = "devplanmcp.store" },
+  { pattern = "mcp.devplanmcp.store/*", zone_name = "devplanmcp.store" }
 ]
 
 # Observability - logs errors and console output


### PR DESCRIPTION
## Summary
- Route MCP endpoints (`/sse`, `/mcp`) to dedicated `mcp.devplanmcp.store` subdomain
- Dashboard analytics now only track real MCP users, not landing page visitors
- Old URLs (`devplanmcp.store/sse`) redirect 301 to new subdomain

## Changes
- **wrangler.toml**: Added mcp subdomain route
- **index.ts**: Subdomain routing logic with appropriate redirects
- **cloudflare-analytics.ts**: Filter queries to `mcp.devplanmcp.store` hostname only
- **README.md & landing.ts**: Updated install URLs

## Test plan
- [x] `devplanmcp.store/sse` → 301 redirect to `mcp.devplanmcp.store/sse`
- [x] `mcp.devplanmcp.store/health` → 200 OK
- [x] `mcp.devplanmcp.store/` → 301 redirect to `devplanmcp.store/`
- [x] Deploy successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)