### PR TITLE
docs: add update instructions for existing installations

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Or add to `~/.claude/mcp.json`:
 }
 ```
 
+### Update Existing Installation
+
+If you already have DevPlan installed, remove and re-add it:
+
+```bash
+claude mcp remove devplan && claude mcp add devplan --transport sse https://mcp.devplanmcp.store/sse
+```
+
 ## Quick Start
 
 ```

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -51,6 +51,9 @@ export function handleLanding(): Response {
     }
   }
 }</code></pre>
+      <h3 class="text-lg font-semibold text-white mt-6 mb-2">Update Existing Installation</h3>
+      <p class="text-gray-400 mb-2">If you already have DevPlan installed, remove and re-add:</p>
+      <pre class="text-yellow-400"><code>claude mcp remove devplan && claude mcp add devplan --transport sse https://mcp.devplanmcp.store/sse</code></pre>
     </section>
 
     <!-- Quick Start -->


### PR DESCRIPTION
## Summary
- Add instructions for updating an existing DevPlan installation
- Users need to remove and re-add if they have an old URL configured

## Changes
- **README.md**: Added "Update Existing Installation" subsection
- **landing.ts**: Added update instructions to landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)