### PR TITLE
fix: remove aggressive bot blocking that broke MCP clients

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1907,15 +1907,7 @@ export default {
 
 		// MCP endpoints - mcp subdomain only (already redirected above if on root domain)
 		if (url.pathname === "/sse" || url.pathname === "/sse/message" || url.pathname === "/mcp") {
-			// Block non-MCP clients to prevent DO bloat from bots/crawlers
-			const userAgent = request.headers.get("User-Agent") || "";
 			const accept = request.headers.get("Accept") || "";
-
-			// Block common bots and crawlers
-			const botPatterns = /bot|crawler|spider|scraper|curl|wget|python-requests|go-http|java\/|php\/|ruby/i;
-			if (botPatterns.test(userAgent)) {
-				return new Response("Forbidden: Bot access not allowed", { status: 403 });
-			}
 
 			// Validate SSE endpoint requests
 			if (url.pathname === "/sse") {


### PR DESCRIPTION
## Summary
- Remove bot blocking that was blocking legitimate MCP client connections
- No longer needed since we moved from DO-based tracking to Cloudflare Analytics

## Problem
SSE endpoint was returning 403 "Bot access not allowed" for Claude Code MCP clients.

## Test
```bash
curl -s https://mcp.devplanmcp.store/sse -H "Accept: text/event-stream"
# Now returns 200 with session ID
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)