### PR TITLE
chore: expand gitignore patterns for planning artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,9 @@ server.json
 dist/
 
 # DevPlan planning artifacts
-PROJECT_BRIEF.md
-DEVELOPMENT_PLAN.md
+PROJECT_BRIEF*.md
+DEVELOPMENT_PLAN*.md
+*PLAN*.md
 CLAUDE.md
 .claude/
 


### PR DESCRIPTION
## Summary
- Use wildcard patterns to ignore all planning artifacts instead of exact filenames
- `PROJECT_BRIEF*.md` catches `PROJECT_BRIEF.md`, `PROJECT_BRIEF_VISUAL_WORKFLOW.md`, etc.
- `DEVELOPMENT_PLAN*.md` catches all development plan variants
- `*PLAN*.md` catches any other plan files like `PLAN-mcp-subdomain.md`

## Test plan
- [x] Verify `git status` no longer shows planning artifacts as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)