### PR TITLE
docs: add Task tool integration to README and landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@
 |---------|-------------|
 | **Haiku-Executable Plans** | Plans so detailed that Claude Haiku can execute them mechanically |
 | **Built-in Validation** | Validates plans are complete before execution begins |
+| **Real-Time Progress Tracking** | Integrates with Claude Code's Task tools for live visibility |
 | **Lessons Learned** | Captures issues from verification and injects them into future plans |
 | **Issue Remediation** | Converts GitHub issues directly into remediation tasks |
-| **Executor & Verifier Agents** | Auto-generates specialized agents for your project |
+| **Executor & Verifier Agents** | Auto-generates specialized agents with task tracking built-in |
 
 ## Install
 
@@ -124,6 +125,24 @@ The validation step checks that plans are truly Haiku-executable:
 }
 ```
 
+### Real-Time Progress with Task Tools
+
+Generated executor and verifier agents integrate with Claude Code's Task tools for live progress visibility:
+
+- **Executor agents** create tasks for each subtask, showing real-time spinners as work progresses
+- **Verifier agents** create tasks for each verification phase (Smoke Tests, Feature Verification, Edge Cases, etc.)
+- Progress is visible without scrolling — you always know what Claude is working on
+
+```
+# Example: Executor tracks subtasks
+TaskCreate({ subject: "1.2.3: Implement auth middleware", activeForm: "Implementing auth middleware" })
+TaskUpdate({ taskId: "...", status: "in_progress" })
+# ... work happens ...
+TaskUpdate({ taskId: "...", status: "completed" })
+```
+
+Both Task tools (real-time visibility) and DEVELOPMENT_PLAN.md (durable record) are updated — giving you the best of both worlds.
+
 ## Usage Examples
 
 ### New Project
@@ -163,8 +182,8 @@ gh issue view 123 --json number,title,body,labels,comments,url > issue.json
 |------|---------|
 | `devplan_generate_plan` | Generate DEVELOPMENT_PLAN.md scaffold with validation instructions |
 | `devplan_generate_claude_md` | Generate CLAUDE.md scaffold |
-| `devplan_generate_executor` | Generate Haiku-powered executor agent |
-| `devplan_generate_verifier` | Generate Sonnet-powered verifier agent |
+| `devplan_generate_executor` | Generate Haiku-powered executor agent with Task tool integration |
+| `devplan_generate_verifier` | Generate Sonnet-powered verifier agent with Task tool integration |
 
 ### Validation & Execution
 

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -97,7 +97,7 @@ export function handleLanding(): Response {
             </li>
             <li class="flex items-start gap-3">
               <span class="text-green-400">✓</span>
-              <span>Copy-paste code that works</span>
+              <span>Real-time progress with Task tools</span>
             </li>
             <li class="flex items-start gap-3">
               <span class="text-green-400">✓</span>
@@ -147,6 +147,11 @@ export function handleLanding(): Response {
           <p class="text-gray-400">Auto-generates executor and verifier agents tailored to your project's tech stack.</p>
         </div>
         <div class="text-center">
+          <div class="benefit-icon mb-4">📊</div>
+          <h3 class="text-xl font-semibold text-white mb-2">Real-Time Progress</h3>
+          <p class="text-gray-400">Integrates with Claude Code's Task tools. See live spinners and progress without scrolling.</p>
+        </div>
+        <div class="text-center">
           <div class="benefit-icon mb-4">📋</div>
           <h3 class="text-xl font-semibold text-white mb-2">As-Built Documentation</h3>
           <p class="text-gray-400">PROJECT_BRIEF.md and DEVELOPMENT_PLAN.md become permanent records. Return months later and understand every decision.</p>
@@ -177,7 +182,7 @@ export function handleLanding(): Response {
         <div class="card rounded-xl p-6 text-center">
           <div class="text-3xl font-bold text-orange-400 mb-2">4</div>
           <h3 class="font-semibold text-white mb-2">Execute</h3>
-          <p class="text-gray-400 text-sm">Haiku implements while Sonnet verifies. Lessons captured for next time.</p>
+          <p class="text-gray-400 text-sm">Haiku implements with live progress tracking. Sonnet verifies. Lessons captured.</p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
Documents the new Task tool integration in executor and verifier agents, added in PRs #109 and #110.

## Changes

### README.md
- Add "Real-Time Progress Tracking" to Key Features table
- Add new section explaining Task tool integration with code example
- Update `devplan_generate_executor` and `devplan_generate_verifier` descriptions to mention task tracking

### Landing Page (src/landing.ts)
- Add new "Real-Time Progress" benefit card with 📊 icon
- Update "With DevPlan" comparison list to include task tracking
- Update "Execute" step description to mention live progress tracking

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 109 tests pass
- [ ] Manual verification: check README renders correctly on GitHub
- [ ] Manual verification: check landing page at devplanmcp.store

🤖 Generated with [Claude Code](https://claude.com/claude-code)