### PR TITLE
fix: Batch bug fixes (#137-#143)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ CLAUDE.md
 
 # Generated types
 worker-configuration.d.ts
+AGENTS.md\nHEARTBEAT.md\nIDENTITY.md\nSOUL.md\nTOOLS.md\nUSER.md

--- a/src/language-defaults.ts
+++ b/src/language-defaults.ts
@@ -164,6 +164,184 @@ export const LANGUAGE_DEFAULTS: Record<string, LanguageDefaults> = {
 		configFile: "go.mod",
 	},
 
+	java: {
+		fileExtension: "java",
+		ignorePatterns: ["target/", "*.class", ".idea/", "*.iml", "build/", ".gradle/", "out/"],
+		projectStructure: [
+			"Create standard Maven/Gradle directory structure",
+			"Create `src/main/java/{package}/` for source files",
+			"Create `src/test/java/{package}/` for tests",
+			"Create `src/main/resources/` for config files",
+			"Initialize build tool (Maven pom.xml or Gradle build.gradle)",
+		],
+		filesToCreate: ["pom.xml", "src/main/java/{package}/Application.java"],
+		successCriteria: [
+			"`mvn compile` or `./gradlew build` succeeds without errors",
+			"Main class exists with valid `main(String[] args)` method",
+			"Build file has project coordinates (groupId, artifactId, version)",
+		],
+		techDecisions: [
+			"Use Maven or Gradle for build automation",
+			"Follow standard Java package naming conventions",
+			"Use Spring Boot for web applications (if applicable)",
+			"Target LTS Java version (17 or 21)",
+		],
+		lintingSetup: [
+			"Add Checkstyle or SpotBugs plugin to build file",
+			"Create `checkstyle.xml` with Google or Sun style rules",
+			"Run `mvn checkstyle:check` or `./gradlew checkstyleMain`",
+		],
+		lintingCriteria: ["Checkstyle reports no violations", "Code compiles without warnings (`-Xlint:all`)"],
+		testingSetup: [
+			"Add JUnit 5 dependency to build file",
+			"Create test class in `src/test/java/{package}/`",
+			"Run `mvn test` or `./gradlew test` to verify",
+		],
+		testingCriteria: ["`mvn test` or `./gradlew test` discovers and runs tests", "JUnit reports test results"],
+		packageManager: "maven",
+		configFile: "pom.xml",
+	},
+
+	kotlin: {
+		fileExtension: "kt",
+		ignorePatterns: ["target/", "*.class", ".idea/", "*.iml", "build/", ".gradle/", "out/"],
+		projectStructure: [
+			"Create Gradle project with Kotlin DSL",
+			"Create `src/main/kotlin/{package}/` for source files",
+			"Create `src/test/kotlin/{package}/` for tests",
+			"Initialize `build.gradle.kts` with Kotlin plugin",
+		],
+		filesToCreate: ["build.gradle.kts", "src/main/kotlin/{package}/Main.kt"],
+		successCriteria: [
+			"`./gradlew build` succeeds without errors",
+			"Main file exists with `fun main()` function",
+			"Kotlin compiler version matches target JVM version",
+		],
+		techDecisions: [
+			"Use Gradle with Kotlin DSL for build automation",
+			"Use Kotlin coroutines for async operations",
+			"Target compatible JVM and Kotlin versions",
+		],
+		lintingSetup: [
+			"Add ktlint or detekt plugin to build.gradle.kts",
+			"Run `./gradlew ktlintCheck` or `./gradlew detekt`",
+		],
+		lintingCriteria: ["`./gradlew ktlintCheck` reports no violations"],
+		testingSetup: [
+			"Add JUnit 5 and kotlin-test dependencies",
+			"Create test class in `src/test/kotlin/{package}/`",
+			"Run `./gradlew test` to verify",
+		],
+		testingCriteria: ["`./gradlew test` discovers and runs tests"],
+		packageManager: "gradle",
+		configFile: "build.gradle.kts",
+	},
+
+	rust: {
+		fileExtension: "rs",
+		ignorePatterns: ["target/", "Cargo.lock", ".env"],
+		projectStructure: [
+			"Run `cargo init` or `cargo new {project}` to initialize",
+			"Create `src/main.rs` for binaries or `src/lib.rs` for libraries",
+			"Create `tests/` directory for integration tests",
+		],
+		filesToCreate: ["Cargo.toml", "src/main.rs"],
+		successCriteria: [
+			"`cargo build` succeeds without errors",
+			"`Cargo.toml` has `[package]` section with name and version",
+			"`cargo run` executes the main function",
+		],
+		techDecisions: [
+			"Use Cargo for dependency management and builds",
+			"Follow Rust API guidelines for public interfaces",
+			"Use `#![deny(warnings)]` in lib.rs for strict compilation",
+		],
+		lintingSetup: [
+			"Run `cargo clippy` for linting (included with rustup)",
+			"Run `cargo fmt --check` for formatting verification",
+			"Add `[lints.clippy]` section to Cargo.toml for custom rules",
+		],
+		lintingCriteria: ["`cargo clippy -- -D warnings` exits with code 0", "`cargo fmt --check` reports no changes"],
+		testingSetup: [
+			"Add `#[cfg(test)]` module to source files for unit tests",
+			"Create `tests/integration_test.rs` for integration tests",
+			"Run `cargo test` to verify test discovery",
+		],
+		testingCriteria: ["`cargo test` discovers and runs all tests", "Tests include both unit and integration tests"],
+		packageManager: "cargo",
+		configFile: "Cargo.toml",
+	},
+
+	csharp: {
+		fileExtension: "cs",
+		ignorePatterns: ["bin/", "obj/", ".vs/", "*.user", "packages/", ".nuget/"],
+		projectStructure: [
+			"Run `dotnet new console` or appropriate template",
+			"Create `src/` directory for source files",
+			"Create `.csproj` project file",
+		],
+		filesToCreate: ["{project}.csproj", "Program.cs"],
+		successCriteria: [
+			"`dotnet build` succeeds without errors",
+			"Project file has valid SDK reference",
+			"`dotnet run` executes without exceptions",
+		],
+		techDecisions: [
+			"Use .NET SDK-style project format",
+			"Target .NET 6+ for modern features",
+			"Use nullable reference types (`<Nullable>enable</Nullable>`)",
+		],
+		lintingSetup: [
+			"Enable code analysis in project file",
+			"Run `dotnet format --verify-no-changes`",
+		],
+		lintingCriteria: ["`dotnet format --verify-no-changes` exits with code 0"],
+		testingSetup: [
+			"Create test project with `dotnet new xunit`",
+			"Add project reference to main project",
+			"Run `dotnet test` to verify",
+		],
+		testingCriteria: ["`dotnet test` discovers and runs tests"],
+		packageManager: "nuget",
+		configFile: "{project}.csproj",
+	},
+
+	ruby: {
+		fileExtension: "rb",
+		ignorePatterns: [".bundle/", "vendor/", "*.gem", ".env", "coverage/"],
+		projectStructure: [
+			"Create `Gemfile` with dependencies",
+			"Create `lib/` directory for source files",
+			"Create `lib/{project}.rb` as main entry point",
+			"Run `bundle init` to initialize Bundler",
+		],
+		filesToCreate: ["Gemfile", "lib/{project}.rb"],
+		successCriteria: [
+			"`bundle install` succeeds",
+			"`ruby lib/{project}.rb` runs without syntax errors",
+			"Gemfile has valid Ruby version constraint",
+		],
+		techDecisions: [
+			"Use Bundler for dependency management",
+			"Follow Ruby style guide conventions",
+			"Use frozen string literals for performance",
+		],
+		lintingSetup: [
+			"Add `rubocop` gem to Gemfile",
+			"Create `.rubocop.yml` with configuration",
+			"Run `bundle exec rubocop`",
+		],
+		lintingCriteria: ["`bundle exec rubocop` exits with code 0"],
+		testingSetup: [
+			"Add `rspec` gem to Gemfile",
+			"Run `bundle exec rspec --init`",
+			"Create `spec/{project}_spec.rb`",
+		],
+		testingCriteria: ["`bundle exec rspec` discovers and runs tests"],
+		packageManager: "bundler",
+		configFile: "Gemfile",
+	},
+
 	static: {
 		fileExtension: "html",
 		ignorePatterns: [".env", "node_modules/", ".DS_Store", "dist/"],


### PR DESCRIPTION
## Summary

Fixes 7 bugs reported from testing:

### #141 - Duplicate subtask ID 1.1.2
- `generateDomainSubtasks` now returns `nextSubtaskNum`
- "First Core Feature" uses dynamic ID based on domain subtasks inserted

### #137 - "unknown" language leaks into scaffold text
- Added `languageDisplay` variable to sanitize "unknown" → "your"
- Updated all prose references in `generateMinimalPhase0`

### #138 - PostgreSQL instead of H2 from brief
- Added H2, Redis, Cassandra, Oracle, SQL Server to `extractTechDetails`

### #140 - Nonsensical file paths for Java
- Added language defaults for Java, Kotlin, Rust, C#, Ruby
- Proper file extensions and project structures per language

### #139 - CLAUDE.md ignores detected language
- Added `getLanguageConfig()` helper with per-language configs
- Updated CLAUDE.md template to use `langConfig` for project structure, tech stack, test commands, lint/type check tools, code style guidelines

### #142 - Lessons not filtered by language
- Added `inferLessonLanguage()` to detect Rust/Python/Go/Java-specific lessons
- Updated `filterLessonsForProject` to accept `targetLanguage` param
- Lessons about cargo/RocksDB now filtered out for Java projects

### #143 - Feature phases treat API endpoints as separate phases
- Added `groupRelatedFeatures()` to detect API endpoint patterns
- Endpoints (GET/POST/PUT/DELETE /path) grouped with preceding feature
- Phase count based on grouped features, not raw feature count

## Testing
- `wrangler deploy --dry-run` passes

Closes #137, #138, #139, #140, #141, #142, #143