### PR TITLE
ci: pin GitHub Actions to commit SHAs for supply chain security

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,10 @@ jobs:
     if: github.ref != 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
@@ -44,10 +44,10 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
@@ -55,6 +55,6 @@ jobs:
         run: npm ci
 
       - name: Deploy to Production
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/reference-repo-updated.yml
+++ b/.github/workflows/reference-repo-updated.yml
@@ -28,7 +28,7 @@ jobs:
       new_hash: ${{ steps.compare.outputs.new_hash }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Fetch reference repo README
         id: fetch
@@ -85,10 +85,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Create or update sync issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const isDispatch = context.eventName === 'repository_dispatch';
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Update stored hash
         run: |


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions in workflow files to full commit SHAs instead of mutable tags
- Affects `deploy.yml` (actions/checkout, actions/setup-node, cloudflare/wrangler-action) and `reference-repo-updated.yml` (actions/checkout, actions/github-script)
- Prevents supply chain attacks where a compromised tag could inject malicious code

## Changes
| Action | Old Ref | New Ref |
|--------|---------|---------|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4` |
| `actions/setup-node` | `@v4` | `@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4` |
| `cloudflare/wrangler-action` | `@v3` | `@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3` |
| `actions/github-script` | `@v7` | `@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7` |