### PR TITLE
feat: add standalone skill — no MCP server required

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "mmorris35",
+  "owner": {
+    "name": "Mike Morris"
+  },
+  "plugins": [
+    {
+      "name": "devplan",
+      "source": ".",
+      "description": "DevPlan skill — interview, brief, Haiku-executable plans, executor/verifier agents. Runs fully local, no MCP server dependency.",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "devplan",
+  "description": "Development plan builder — interview, brief, Haiku-executable plans, executor/verifier agents. No MCP dependency.",
+  "version": "1.0.0",
+  "keywords": [
+    "devplan",
+    "planning",
+    "development",
+    "haiku",
+    "executor",
+    "verifier"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,93 @@
 >
 > **The Solution**: DevPlan creates detailed, agent-executable development plans with built-in validation, lessons learned, and inline git workflows.
 
+---
+
+## NEW — Install as a Skill (No MCP Server Required)
+
+DevPlan is now available as a **standalone Claude Code skill** — no MCP server, no network dependency, no SSE timeouts. The entire DevPlan methodology runs locally as a first-class plugin.
+
+### Install
+
+**Step 1** — Add this repo as a plugin marketplace:
+
+```bash
+/plugin marketplace add mmorris35/devplan-mcp-server
+```
+
+**Step 2** — Install the plugin at user scope (available across all projects):
+
+```bash
+/plugin install devplan@mmorris35 --scope user
+```
+
+**Step 3** — Reload plugins to activate:
+
+```bash
+/reload-plugins
+```
+
+### Usage
+
+Invoke the skill directly:
+
+```
+/devplan
+```
+
+Or use specific sub-commands:
+
+```
+/devplan brief          — Create or parse a PROJECT_BRIEF.md
+/devplan plan           — Generate a Haiku-executable DEVELOPMENT_PLAN.md
+/devplan agents         — Generate executor (Haiku) and verifier (Sonnet) agents
+/devplan claude-md      — Generate a project CLAUDE.md
+/devplan validate       — Check plan structure and Haiku-executability
+/devplan progress       — Show completion status
+/devplan export mermaid — Generate a Mermaid flowchart of the plan
+/devplan issue <number> — Convert a GitHub issue to a remediation task
+/devplan implement      — Kickoff the build with executor + verifier agents
+```
+
+Or just describe what you need — Claude will invoke the skill automatically:
+
+```
+"Help me plan a CLI tool for managing dotfiles"
+"Create a development plan for this project"
+"Validate my development plan"
+```
+
+### What's Included
+
+```
+skills/devplan/
+├── SKILL.md                 — Core methodology, interview flow, dispatch
+├── references/
+│   ├── templates.md         — Brief/plan/CLAUDE.md templates (CLI, web app, API, library)
+│   ├── validation.md        — Structure + Haiku-executability rules + battle-tested lessons
+│   ├── agents.md            — Executor and verifier agent generation patterns
+│   └── workflows.md         — Mermaid/ReactFlow export + progress tracking
+├── scripts/
+│   ├── validate-plan.sh     — Structural validation (standalone)
+│   └── check-haiku.sh       — Haiku-executability checker (standalone)
+└── examples/
+    └── hello-cli-plan.md    — Gold standard reference plan
+```
+
+### Skill vs MCP Server
+
+| | Skill (NEW) | MCP Server |
+|---|---|---|
+| **Network** | None required | SSE connection to Cloudflare |
+| **Reliability** | Always works | Subject to SSE timeouts |
+| **Lessons system** | Use [Nellie](https://github.com/mmorris35/nellie) or your own | Built-in KV store |
+| **Install** | `/plugin install` | `claude mcp add` |
+| **Validation scripts** | Standalone bash | Server-side |
+
+Both options are fully supported. The skill is recommended for reliability; the MCP server adds the lessons learned system and usage analytics.
+
+---
+
 ## Key Features
 
 | Feature | Description |

--- a/skills/devplan/SKILL.md
+++ b/skills/devplan/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: devplan
+description: >-
+  Use this skill when the user asks to "plan a project", "create a development plan",
+  "start a new project", "build a dev plan", "generate a plan", "interview me for a project",
+  "create a brief", "make a project brief", or mentions devplan, development planning,
+  Haiku-executable plans, executor agents, or verifier agents. Also use when the user says
+  "plan this", "scope this out", or asks for a structured implementation plan for any
+  software project. Covers the full lifecycle: interview, brief, plan, agents, verification.
+user-invocable: true
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash(ls *)
+  - Bash(mkdir *)
+  - Bash(grep *)
+  - Bash(wc *)
+  - Bash(cat *)
+---
+
+# /devplan — Development Plan Builder
+
+Build Haiku-executable development plans from interview through verification.
+No MCP server required — everything runs locally as skill instructions + templates.
+
+Arguments passed: `$ARGUMENTS`
+
+---
+
+## What This Skill Does
+
+Takes a software project from idea to structured, executable plan:
+
+1. **Interview** — gather requirements through focused questions
+2. **Brief** — create PROJECT_BRIEF.md capturing the spec
+3. **Plan** — generate DEVELOPMENT_PLAN.md with complete, copy-pasteable code
+4. **Agents** — create executor (Haiku) and verifier (Sonnet) agent files
+5. **Track** — monitor progress and export visualizations
+6. **Verify** — validate the built application against the brief
+
+## Dispatch on Arguments
+
+### No args — start the full workflow
+
+Begin with the interview. Ask questions ONE AT A TIME, waiting for each response:
+
+1. "What's your project name?"
+2. "What type of project is this? (CLI tool, web app, API, or library)"
+3. "In one sentence, what does it do?"
+4. "Who will use it? (e.g., developers, end users, admins)"
+5. "What are the 3-5 must-have features for MVP?"
+6. "Any technologies you must use or cannot use?"
+7. "What's your timeline?"
+8. "Any constraints I should know about?"
+
+After gathering answers, proceed to brief creation.
+
+### `brief` — create or parse a brief
+
+If a PROJECT_BRIEF.md exists, read and parse it. Otherwise create one from the
+interview answers. See `references/templates.md` for the brief template.
+
+Write the brief to `PROJECT_BRIEF.md` in the project root.
+
+### `plan` — generate the development plan
+
+Requires a PROJECT_BRIEF.md (create one first if missing).
+
+**Critical**: Read `references/templates.md` for the plan structure template,
+then read `examples/hello-cli-plan.md` for the gold standard example of what
+a finished plan looks like.
+
+Generate the plan following these rules:
+
+1. **Structure**: Phases > Tasks > Subtasks (e.g., 1.1.1, 2.3.2)
+2. **Scope**: Each subtask is one session (2-4 hours max)
+3. **Completeness**: Every subtask MUST have complete, copy-pasteable code blocks
+4. **Verification**: Every subtask MUST have verification commands with expected output
+5. **Git workflow**: One branch per TASK (not subtask). Squash merge when task completes.
+
+Read `references/validation.md` for the full Haiku-executability rules and common
+pitfalls to avoid.
+
+Write to `DEVELOPMENT_PLAN.md` in the project root.
+
+### `agents` — generate executor and verifier agents
+
+Read `references/agents.md` for the agent templates. Generate:
+
+- `.claude/agents/{project}-executor.md` — Haiku-powered, executes subtasks mechanically
+- `.claude/agents/{project}-verifier.md` — Sonnet-powered, validates against brief
+
+### `claude-md` — generate project CLAUDE.md
+
+Generate a CLAUDE.md with project overview, tech stack, directory structure,
+commands, coding standards, and session checklists. Tailored to the project type.
+
+### `validate` — check plan quality
+
+Read the DEVELOPMENT_PLAN.md and validate it against the rules in
+`references/validation.md`. Check both structural completeness and
+Haiku-executability. Report specific issues with fix instructions.
+
+### `progress` — show completion status
+
+Parse DEVELOPMENT_PLAN.md checkbox states to show:
+- Overall completion percentage
+- Phase-by-phase progress
+- Next actionable subtask
+- Recently completed work
+
+### `export mermaid` — generate Mermaid diagram
+
+Read `references/workflows.md` for the export format. Parse the plan and
+generate a Mermaid flowchart showing phases, tasks, dependencies, and status.
+
+### `export reactflow` — generate ReactFlow JSON
+
+Read `references/workflows.md` for the ReactFlow export format.
+
+### `issue <number>` — convert GitHub issue to remediation task
+
+Fetch the issue with `gh issue view <number> --json number,title,body,labels,comments,url`,
+then generate a remediation task with subtasks following the same plan format.
+Can be appended to an existing DEVELOPMENT_PLAN.md or written as a standalone
+REMEDIATION_PLAN.md.
+
+### `implement` — kickoff the build
+
+Print instructions for using the executor agent to build subtask-by-subtask,
+then the verifier agent to validate. Remind the user to run verification
+after the executor finishes.
+
+---
+
+## Core Methodology: Haiku-Executable Plans
+
+The defining principle: **every subtask must contain complete, working code that
+Claude Haiku can copy-paste and execute without interpretation.**
+
+If you write `{placeholder}`, `// TODO`, or "implement the logic here" — it is
+NOT Haiku-executable. Haiku treats each subtask independently and cannot infer
+missing details from earlier context.
+
+### What Haiku-Executable Looks Like
+
+```markdown
+**Subtask 1.1.1: Create configuration file**
+
+**Complete Code:**
+
+Create file `src/config.py`:
+\`\`\`python
+import os
+from dataclasses import dataclass
+
+@dataclass
+class Config:
+    api_key: str
+    base_url: str = "https://api.example.com"
+    timeout: int = 30
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        return cls(
+            api_key=os.environ["API_KEY"],
+            base_url=os.getenv("BASE_URL", "https://api.example.com"),
+            timeout=int(os.getenv("TIMEOUT", "30")),
+        )
+\`\`\`
+
+**Verification:**
+\`\`\`bash
+python -c "from config import Config; c = Config(api_key='test'); print(c.base_url)"
+# Expected: https://api.example.com
+\`\`\`
+```
+
+### Critical Rules (From Battle-Tested Experience)
+
+1. **Repeat instructions per-subtask** — Haiku does not carry forward implicit
+   instructions from earlier in the document. Include ALL required commands
+   (git, verification, completion steps) explicitly in EVERY subtask.
+
+2. **No TODO stubs** — Split large subtasks rather than leaving stubs. Verification
+   must grep for TODO/FIXME and fail if any remain.
+
+3. **Complete imports in every file** — Every code block must include all imports.
+   Never assume a prior subtask's imports carry over.
+
+4. **Test mocks must match production models** — Use model_construct() or inherit
+   from real classes. Never hand-write mock dataclasses for Pydantic models.
+
+5. **Verify integration, not just units** — Every subtask touching app state must
+   also verify the wiring (lifespan, middleware, etc.) actually works at runtime.
+
+6. **Large files need chunked strategy** — For files over 500 lines, subtasks must
+   use grep to find target sections, read with offset/limit, and edit surgically.
+
+7. **Subtask heading format matters** — Use `**Subtask X.Y.Z: Title**` (bold text),
+   not `### Task X.Y` headings. Validators only recognize the bold format.
+
+8. **3-7 deliverables per subtask** — Too few means the subtask is trivial (merge it).
+   Too many means it's too large (split it).
+
+---
+
+## Workflow Summary
+
+After planning is complete, explain this to the user:
+
+### Phase 1: Build (Executor Agent)
+```
+Use the {project}-executor agent to execute subtask [X.Y.Z]
+```
+
+### Phase 2: Verify (Don't Skip!)
+```
+Use the {project}-verifier agent to validate against PROJECT_BRIEF.md
+```
+
+### Phase 3: Capture Lessons
+Save any issues the verifier found as Nellie lessons for future projects.
+
+---
+
+## Reference Files
+
+Load these as needed — do not load all at once:
+
+- `references/templates.md` — Brief, plan, and CLAUDE.md templates for all 4 project types
+- `references/validation.md` — Structural + Haiku-executability validation rules
+- `references/agents.md` — Executor and verifier agent generation templates
+- `references/workflows.md` — Mermaid and ReactFlow export formats
+- `examples/hello-cli-plan.md` — Gold standard example plan (study this before generating any plan)

--- a/skills/devplan/examples/hello-cli-plan.md
+++ b/skills/devplan/examples/hello-cli-plan.md
@@ -1,0 +1,544 @@
+# HelloCLI — Gold Standard Example Plan
+
+This is the reference example of a Haiku-executable development plan.
+Study this before generating any plan.
+
+> **Note**: This example uses `### Subtask` headings for readability. When
+> generating plans for validation, use `**Subtask X.Y.Z: Title**` bold format
+> instead, as validators only recognize that pattern.
+
+---
+
+# DEVELOPMENT_PLAN.md - HelloCLI
+
+> **Haiku-Executable Plan**: Every subtask contains complete, copy-pasteable code. Claude Haiku can execute this mechanically without inference.
+
+## Project Summary
+
+| Field | Value |
+|-------|-------|
+| **Project** | HelloCLI |
+| **Goal** | Minimal CLI that greets users by name with optional color output |
+| **Phases** | 2 |
+| **Tasks** | 4 |
+| **Subtasks** | 6 |
+
+---
+
+## Phase Overview
+
+| Phase | Name | Tasks | Status |
+|-------|------|-------|--------|
+| 1 | Project Setup | 2 | Pending |
+| 2 | CLI Implementation | 2 | Pending |
+
+---
+
+# Phase 1: Project Setup
+
+## Task 1.1: Initialize Project Structure
+
+**Branch:** `feature/1.1-project-init`
+
+**Subtask 1.1.1: Create pyproject.toml**
+
+**Prerequisites:** None
+
+**Deliverables:**
+- [ ] `pyproject.toml` - Project configuration
+
+**Complete Code:**
+
+Create file `pyproject.toml`:
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hello-cli"
+version = "0.1.0"
+description = "A minimal CLI that greets users by name"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "click>=8.1.0",
+    "rich>=13.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "ruff>=0.1.0",
+    "mypy>=1.0.0",
+]
+
+[project.scripts]
+hello = "hello_cli.cli:main"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_ignores = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --cov=hello_cli --cov-report=term-missing"
+
+[tool.coverage.run]
+source = ["src/hello_cli"]
+branch = true
+
+[tool.coverage.report]
+fail_under = 100
+show_missing = true
+```
+
+**Verification:**
+```bash
+python -c "import tomllib; tomllib.load(open('pyproject.toml', 'rb'))"
+# Expected: No output (success)
+```
+
+**Success Criteria:**
+- [ ] `pyproject.toml` exists
+- [ ] TOML parses without error
+- [ ] All dependencies listed
+
+**Completion Notes:**
+- **Implementation**: (filled by executor)
+- **Files Created**: `pyproject.toml`
+- **Verification**: (filled by executor)
+
+---
+
+**Subtask 1.1.2: Create Package Structure**
+
+**Prerequisites:** 1.1.1 complete
+
+**Deliverables:**
+- [ ] `src/hello_cli/__init__.py` - Package init with version
+- [ ] `src/hello_cli/cli.py` - CLI placeholder
+- [ ] `tests/__init__.py` - Test package init
+
+**Complete Code:**
+
+Create file `src/hello_cli/__init__.py`:
+```python
+"""HelloCLI - A minimal greeting CLI."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+__all__ = ["__version__"]
+```
+
+Create file `src/hello_cli/cli.py`:
+```python
+"""CLI entry point for HelloCLI."""
+
+from __future__ import annotations
+
+
+def main() -> None:
+    """Entry point placeholder."""
+    pass
+```
+
+Create file `tests/__init__.py`:
+```python
+"""Test package for HelloCLI."""
+```
+
+**Verification:**
+```bash
+ls -la src/hello_cli/
+# Expected: __init__.py, cli.py
+
+ls -la tests/
+# Expected: __init__.py
+
+python -c "from hello_cli import __version__; print(__version__)"
+# Expected: 0.1.0
+```
+
+**Success Criteria:**
+- [ ] Package structure created
+- [ ] `__version__` importable
+- [ ] Tests directory exists
+
+**Completion Notes:**
+- **Implementation**: (filled by executor)
+- **Files Created**: `src/hello_cli/__init__.py`, `src/hello_cli/cli.py`, `tests/__init__.py`
+- **Verification**: (filled by executor)
+
+---
+
+### Task 1.1 Complete - Squash Merge
+
+```bash
+git push -u origin feature/1.1-project-init
+git checkout main
+git pull origin main
+git merge --squash feature/1.1-project-init
+git commit -m "feat(setup): initialize project structure
+
+- Add pyproject.toml with dependencies
+- Create src/hello_cli package structure
+- Add tests directory"
+git push origin main
+git branch -d feature/1.1-project-init
+git push origin --delete feature/1.1-project-init
+```
+
+- [ ] All subtasks complete (1.1.1, 1.1.2)
+- [ ] All verification passes
+- [ ] Squash merged to main
+- [ ] Feature branch deleted
+
+---
+
+## Task 1.2: Install and Verify
+
+**Branch:** `feature/1.2-install-verify`
+
+**Subtask 1.2.1: Install Dev Dependencies and Verify Tools**
+
+**Prerequisites:** Task 1.1 complete
+
+**Deliverables:**
+- [ ] Package installed in editable mode
+- [ ] All dev tools working
+
+**Complete Code:**
+
+Commands to execute:
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+ruff --version
+# Expected: ruff 0.x.x
+mypy --version
+# Expected: mypy 1.x.x
+pytest --version
+# Expected: pytest 7.x.x
+```
+
+**Verification:**
+```bash
+hello --help || true
+# Expected: Error (no --help implemented yet) - this is OK
+
+python -c "from hello_cli import __version__; print('OK')"
+# Expected: OK
+```
+
+**Success Criteria:**
+- [ ] `pip install -e ".[dev]"` succeeds
+- [ ] `ruff --version` works
+- [ ] `mypy --version` works
+- [ ] `pytest --version` works
+
+**Completion Notes:**
+- **Implementation**: (filled by executor)
+- **Verification**: (filled by executor)
+
+---
+
+### Task 1.2 Complete - Squash Merge
+
+```bash
+git push -u origin feature/1.2-install-verify
+git checkout main
+git pull origin main
+git merge --squash feature/1.2-install-verify
+git commit -m "chore(setup): install and verify dev dependencies
+
+- Install package in editable mode
+- Verify ruff, mypy, pytest work"
+git push origin main
+git branch -d feature/1.2-install-verify
+git push origin --delete feature/1.2-install-verify
+```
+
+- [ ] All subtasks complete (1.2.1)
+- [ ] All verification passes
+- [ ] Squash merged to main
+- [ ] Feature branch deleted
+
+---
+
+# Phase 2: CLI Implementation
+
+## Task 2.1: Implement Core CLI
+
+**Branch:** `feature/2.1-core-cli`
+
+**Subtask 2.1.1: Implement Greeting Command**
+
+**Prerequisites:** Task 1.2 complete
+
+**Deliverables:**
+- [ ] `src/hello_cli/cli.py` - Full CLI implementation
+- [ ] `tests/test_cli.py` - Complete test suite (8 tests)
+
+**Complete Code:**
+
+Replace `src/hello_cli/cli.py` with:
+```python
+"""CLI entry point for HelloCLI."""
+
+from __future__ import annotations
+
+import click
+from rich.console import Console
+
+from hello_cli import __version__
+
+console = Console()
+
+
+@click.command()
+@click.argument("name", default="World")
+@click.option("--color", is_flag=True, help="Use colored output")
+@click.version_option(version=__version__, prog_name="hello-cli")
+def main(name: str, color: bool) -> None:
+    """Greet NAME with a friendly message.
+
+    If no NAME is provided, greets "World" by default.
+
+    Examples:
+        hello Alice        -> Hello, Alice!
+        hello --color Bob  -> Hello, Bob! (in green)
+    """
+    message = f"Hello, {name}!"
+
+    if color:
+        console.print(message, style="bold green")
+    else:
+        click.echo(message)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Create file `tests/test_cli.py`:
+```python
+"""Tests for HelloCLI."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from hello_cli import __version__
+from hello_cli.cli import main
+
+
+class TestGreetCommand:
+    """Test suite for the greet command."""
+
+    def test_greet_default_name(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, [])
+        assert result.exit_code == 0
+        assert "Hello, World!" in result.output
+
+    def test_greet_custom_name(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["Alice"])
+        assert result.exit_code == 0
+        assert "Hello, Alice!" in result.output
+
+    def test_greet_with_color_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["Bob", "--color"])
+        assert result.exit_code == 0
+        assert "Bob" in result.output
+
+    def test_version_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        assert __version__ in result.output
+        assert "hello-cli" in result.output
+
+    def test_help_flag(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "Greet NAME" in result.output
+        assert "--color" in result.output
+        assert "--version" in result.output
+
+
+class TestEdgeCases:
+    """Test edge cases."""
+
+    def test_empty_string_name(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, [""])
+        assert result.exit_code == 0
+        assert "Hello, !" in result.output
+
+    def test_name_with_spaces(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["John Doe"])
+        assert result.exit_code == 0
+        assert "Hello, John Doe!" in result.output
+
+    def test_special_characters_in_name(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["Jose Garcia"])
+        assert result.exit_code == 0
+        assert "Hello, Jose Garcia!" in result.output
+```
+
+**Verification:**
+```bash
+ruff check src tests
+# Expected: All checks passed!
+
+mypy src
+# Expected: Success: no issues found
+
+pytest tests/ -v --cov=hello_cli --cov-report=term-missing
+# Expected: 8 passed, 100% coverage
+```
+
+**Success Criteria:**
+- [ ] `ruff check src tests` passes
+- [ ] `mypy src` passes
+- [ ] `pytest` shows 8 tests passing
+- [ ] Coverage is 100%
+
+**Completion Notes:**
+- **Implementation**: (filled by executor)
+- **Files Created**: `tests/test_cli.py`
+- **Files Modified**: `src/hello_cli/cli.py`
+- **Tests**: 8 tests, 100% coverage
+- **Verification**: (filled by executor)
+
+---
+
+### Task 2.1 Complete - Squash Merge
+
+```bash
+git push -u origin feature/2.1-core-cli
+git checkout main
+git pull origin main
+git merge --squash feature/2.1-core-cli
+git commit -m "feat(cli): implement greeting command
+
+- Add click-based CLI with name argument
+- Add --color flag for Rich output
+- Add --version and --help flags
+- 8 tests, 100% coverage"
+git push origin main
+git branch -d feature/2.1-core-cli
+git push origin --delete feature/2.1-core-cli
+```
+
+- [ ] All subtasks complete (2.1.1)
+- [ ] All tests pass with 100% coverage
+- [ ] Squash merged to main
+- [ ] Feature branch deleted
+
+---
+
+## Task 2.2: Final Verification
+
+**Branch:** `feature/2.2-final-verify`
+
+**Subtask 2.2.1: End-to-End Testing**
+
+**Prerequisites:** Task 2.1 complete
+
+**Deliverables:**
+- [ ] CLI works from command line
+- [ ] All flags function correctly
+
+**Complete Code:**
+
+Commands to execute:
+```bash
+hello
+# Expected: Hello, World!
+
+hello Alice
+# Expected: Hello, Alice!
+
+hello Bob --color
+# Expected: Hello, Bob! (in green)
+
+hello --version
+# Expected: hello-cli, version 0.1.0
+
+hello --help
+# Expected: Usage info with all options
+```
+
+**Verification:**
+```bash
+hello && hello Alice && hello --version && hello --help
+# Expected: All succeed (exit 0)
+
+pytest tests/ -v --cov=hello_cli --cov-report=term-missing --cov-fail-under=100
+# Expected: 8 passed, 100% coverage, exit 0
+```
+
+**Success Criteria:**
+- [ ] `hello` outputs "Hello, World!"
+- [ ] `hello Alice` outputs "Hello, Alice!"
+- [ ] `hello --version` shows version
+- [ ] `hello --help` shows help
+- [ ] All tests pass with 100% coverage
+
+**Completion Notes:**
+- **Implementation**: (filled by executor)
+- **Verification**: (filled by executor)
+
+---
+
+### Task 2.2 Complete - Squash Merge
+
+```bash
+git push -u origin feature/2.2-final-verify
+git checkout main
+git pull origin main
+git merge --squash feature/2.2-final-verify
+git commit -m "test(cli): complete end-to-end verification
+
+- Verify all CLI commands work
+- Confirm 100% test coverage
+- All quality checks pass"
+git push origin main
+git branch -d feature/2.2-final-verify
+git push origin --delete feature/2.2-final-verify
+```
+
+- [ ] All subtasks complete (2.2.1)
+- [ ] All verification passes
+- [ ] Squash merged to main
+- [ ] Feature branch deleted
+
+---
+
+# Project Complete Checklist
+
+- [ ] Phase 1: Project Setup complete
+- [ ] Phase 2: CLI Implementation complete
+- [ ] All tests pass (8 tests)
+- [ ] 100% code coverage
+- [ ] CLI works: `hello`, `hello NAME`, `hello --color`, `hello --version`, `hello --help`
+- [ ] Clean git history (squash merges only)

--- a/skills/devplan/references/agents.md
+++ b/skills/devplan/references/agents.md
@@ -1,0 +1,247 @@
+# DevPlan Agent Generation
+
+Templates for creating project-specific executor and verifier agents.
+These go in `.claude/agents/{project}-executor.md` and `.claude/agents/{project}-verifier.md`.
+
+---
+
+## Executor Agent Template
+
+The executor is Haiku-powered — fast, cheap, mechanical. It follows the plan
+literally without creative interpretation. That's the whole point.
+
+```markdown
+---
+name: {project}-executor
+description: PROACTIVELY use this agent to execute {project} development subtasks. Reads DEVELOPMENT_PLAN.md and implements each subtask mechanically.
+tools: Read, Write, Edit, Bash, Glob, Grep
+model: haiku
+---
+
+# {Project} Executor Agent
+
+You execute subtasks from DEVELOPMENT_PLAN.md. Follow instructions literally.
+Do not improvise, skip steps, or make creative decisions.
+
+## Before Starting Any Subtask
+
+1. Read CLAUDE.md completely — it has project conventions and commands
+2. Read DEVELOPMENT_PLAN.md completely
+3. Find the assigned subtask (or the next uncompleted one)
+4. Check prerequisites are met (prior subtasks marked complete)
+5. Create/checkout the correct feature branch if not already on it
+
+## Execution Loop
+
+For each deliverable checkbox in the subtask:
+
+1. Read the "Complete Code" section for that deliverable
+2. Create or modify the file exactly as specified
+3. Run the verification command
+4. If verification fails: fix the issue, re-verify
+5. Mark the deliverable checkbox as complete in the plan
+
+## After Completing All Deliverables
+
+1. Run all verification commands from the Success Criteria section
+2. Fill in ALL Completion Notes fields:
+   - **Implementation**: What was done (1-2 sentences)
+   - **Files Created**: List with line counts
+   - **Files Modified**: List
+   - **Tests**: Count and coverage percentage
+   - **Build**: pass/fail
+   - **Branch**: Current branch name
+3. Commit with semantic message: `{type}({scope}): {description}`
+4. Report what was done
+
+## Large File Protocol
+
+For files over 500 lines:
+- NEVER read the entire file
+- Use Grep to find target sections first
+- Read with offset/limit to view 50-100 line chunks
+- Use Edit for surgical changes
+- Verify edits with targeted Grep after each change
+- For bulk changes, process in batches of 5-10 matches
+
+## Error Recovery
+
+- **Tests fail**: Fix immediately before continuing to next deliverable
+- **Missing dependency**: Check if a prerequisite subtask was skipped
+- **Blocked**: Document the blocker in Completion Notes, move to next deliverable
+- **Unclear instruction**: Check CLAUDE.md first, then PROJECT_BRIEF.md
+- **File conflict**: Read the current file state, adapt the edit to match
+
+## Things You Must NOT Do
+
+- Do not skip verification commands
+- Do not leave TODO/FIXME comments in code
+- Do not modify files outside the subtask's deliverables list
+- Do not interpret vague instructions — if it's unclear, flag it in Completion Notes
+- Do not merge branches — only the orchestrator does that
+```
+
+---
+
+## Verifier Agent Template
+
+The verifier is Sonnet-powered — smarter, more analytical. It tries to break
+the application and find gaps between what the brief promised and what was built.
+
+```markdown
+---
+name: {project}-verifier
+description: Validate the completed {project} application against PROJECT_BRIEF.md requirements. Run AFTER the executor finishes all subtasks.
+tools: Read, Bash, Glob, Grep
+model: sonnet
+---
+
+# {Project} Verifier Agent
+
+You validate that the built application matches the PROJECT_BRIEF.md spec.
+Your job is to find gaps, not confirm success.
+
+## Verification Process
+
+### 1. Read Requirements
+- Read PROJECT_BRIEF.md for the authoritative feature list
+- Read DEVELOPMENT_PLAN.md for what was planned
+- Note any discrepancies between brief and plan
+
+### 2. Smoke Test
+- Install dependencies: `{install command}`
+- Start the application: `{start command}`
+- Verify it runs without errors
+
+### 3. Feature Verification
+For EACH feature in PROJECT_BRIEF.md "Must-Have (MVP)":
+
+1. Identify the feature
+2. Test the happy path
+3. Test edge cases (empty input, large input, special characters)
+4. Test error handling (invalid input, missing dependencies)
+5. Record PASS or FAIL with evidence
+
+### 4. Code Quality Check
+- Run linter: `{lint command}`
+- Run type checker: `{typecheck command}`
+- Run tests: `{test command}`
+- Check coverage meets target
+- Grep for TODO/FIXME: `grep -rn 'TODO\|FIXME' src/`
+
+### 5. Security Scan (if applicable)
+- Check for hardcoded secrets: `grep -rn 'password\|secret\|api_key\|token' src/ --include='*.{py,ts,js}'`
+- Verify no .env files committed
+- Check for SQL injection (parameterized queries)
+- Check for XSS (output encoding)
+
+## Report Format
+
+Generate a verification report:
+
+```markdown
+# Verification Report: {Project}
+
+**Date**: {date}
+**Brief Version**: {hash or date of PROJECT_BRIEF.md}
+**Verdict**: PASS / FAIL / PARTIAL
+
+## Feature Results
+
+| # | Feature | Status | Notes |
+|---|---------|--------|-------|
+| 1 | {feature} | PASS/FAIL | {evidence} |
+| 2 | {feature} | PASS/FAIL | {evidence} |
+
+## Quality Results
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Lint | PASS/FAIL | {output} |
+| Types | PASS/FAIL | {output} |
+| Tests | PASS/FAIL | {count} passed, {coverage}% |
+| TODOs | PASS/FAIL | {count} found |
+
+## Issues Found
+
+### Issue 1: {Title}
+- **Severity**: Critical / Warning / Info
+- **Description**: {what's wrong}
+- **Expected**: {what brief says}
+- **Actual**: {what was built}
+- **Fix**: {suggested fix}
+
+## Recommendations
+
+- {recommendation 1}
+- {recommendation 2}
+```
+
+## After Verification
+
+Save any issues as Nellie lessons for future projects. Each issue becomes:
+- **Pattern**: Short identifier for the failure mode
+- **Issue**: What went wrong
+- **Root Cause**: Why it happened
+- **Fix**: How to prevent it next time
+```
+
+---
+
+## Customizing Agents Per Project
+
+### Language-Specific Executor Additions
+
+**Python projects** — add to executor:
+```markdown
+## Python Conventions
+- Use `from __future__ import annotations` in every file
+- Run `ruff check src tests` before committing
+- Run `mypy src` before committing
+- Target coverage: {N}%
+```
+
+**TypeScript projects** — add to executor:
+```markdown
+## TypeScript Conventions
+- Use strict mode in tsconfig.json
+- No `any` types — use `unknown` and narrow
+- Run `eslint . && tsc --noEmit` before committing
+- Target coverage: {N}%
+```
+
+**Rust projects** — add to executor:
+```markdown
+## Rust Conventions
+- Run `cargo fmt --check && cargo clippy -- -D warnings && cargo test` SEQUENTIALLY (never parallel)
+- First build with RocksDB or other C deps may take 30+ minutes — do not start other work
+- Do not switch branches during heavy native builds (invalidates cache)
+```
+
+### API-Specific Verifier Additions
+
+For API projects, add endpoint testing:
+```markdown
+## API Endpoint Testing
+
+For each endpoint in the brief:
+1. Test with valid request → expect 2xx
+2. Test with missing auth → expect 401
+3. Test with invalid body → expect 422
+4. Test with non-existent resource → expect 404
+5. Record response times
+```
+
+### Web App-Specific Verifier Additions
+
+For web apps, add UI testing:
+```markdown
+## UI Testing
+
+For each page/feature:
+1. Load the page — no console errors
+2. Test core interaction (click, submit, navigate)
+3. Test responsive behavior (mobile viewport)
+4. Test with JavaScript disabled (graceful degradation)
+5. Screenshot evidence for each test
+```

--- a/skills/devplan/references/templates.md
+++ b/skills/devplan/references/templates.md
@@ -1,0 +1,480 @@
+# DevPlan Templates
+
+Templates for PROJECT_BRIEF.md, DEVELOPMENT_PLAN.md, and CLAUDE.md across all
+four project types (CLI, Web App, API, Library).
+
+---
+
+## PROJECT_BRIEF.md Template
+
+```markdown
+# Project Brief: {name}
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| **Project Name** | {name} |
+| **Project Type** | {cli / web_app / api / library} |
+| **Goal** | {one sentence} |
+| **Timeline** | {timeline} |
+| **Team Size** | 1 |
+
+## Target Users
+
+- {user type 1}
+- {user type 2}
+
+## Features
+
+### Must-Have (MVP)
+
+1. **{Feature Name}** - {description}
+2. **{Feature Name}** - {description}
+3. **{Feature Name}** - {description}
+
+### Nice-to-Have (v2)
+
+- {feature}
+- {feature}
+
+## Technical Requirements
+
+### Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Language | {language} |
+| Framework | {framework} |
+| Testing | {test framework} |
+| Linting | {linter} |
+
+### Constraints
+
+- {constraint 1}
+- {constraint 2}
+
+## Success Criteria
+
+1. {criterion 1}
+2. {criterion 2}
+3. {criterion 3}
+
+## Out of Scope
+
+- {thing 1}
+- {thing 2}
+```
+
+---
+
+## DEVELOPMENT_PLAN.md Structure
+
+### Header
+
+```markdown
+# DEVELOPMENT_PLAN.md - {ProjectName}
+
+> **Haiku-Executable Plan**: Every subtask contains complete, copy-pasteable
+> code. Claude Haiku can execute this mechanically without inference.
+
+## Project Summary
+
+| Field | Value |
+|-------|-------|
+| **Project** | {name} |
+| **Goal** | {one-sentence goal} |
+| **Phases** | {count} |
+| **Tasks** | {count} |
+| **Subtasks** | {count} |
+
+---
+
+## Phase Overview
+
+| Phase | Name | Tasks | Status |
+|-------|------|-------|--------|
+| 0 | Project Setup | {n} | Pending |
+| 1 | Core Implementation | {n} | Pending |
+| 2 | Polish & Verify | {n} | Pending |
+```
+
+### Subtask Template
+
+Every subtask MUST include ALL of these sections:
+
+```markdown
+**Subtask X.Y.Z: {Title}**
+
+**Prerequisites:**
+- [x] X.Y.W: {Previous subtask title}
+
+**Deliverables:**
+- [ ] `path/to/file.ext` - {what this file does}
+- [ ] `path/to/test.ext` - {tests for the above}
+- [ ] {3-7 total deliverables}
+
+**Technology Decisions:**
+- {library/pattern choice with rationale}
+
+**Complete Code:**
+
+Create file `path/to/file.ext`:
+\`\`\`{language}
+{COMPLETE, working code — all imports, no placeholders}
+\`\`\`
+
+Create file `path/to/test.ext`:
+\`\`\`{language}
+{COMPLETE test file — all imports, all fixtures, no external deps}
+\`\`\`
+
+**Verification:**
+\`\`\`bash
+{exact command to run}
+# Expected: {exact expected output}
+\`\`\`
+
+**Success Criteria:**
+- [ ] {Testable condition}
+- [ ] {Another testable condition}
+- [ ] All tests pass
+
+**Completion Notes:**
+- **Implementation**: (filled by executor)
+- **Files Created**: (filled by executor)
+- **Files Modified**: (filled by executor)
+- **Tests**: (X tests, Y% coverage)
+- **Build**: (pass/fail)
+- **Branch**: (branch name)
+```
+
+### Task Complete Section
+
+After each task's subtasks:
+
+```markdown
+### Task X.Y Complete - Squash Merge
+
+**When all subtasks are complete, execute:**
+
+\`\`\`bash
+git push -u origin feature/X-Y-{name}
+git checkout main
+git pull origin main
+git merge --squash feature/X-Y-{name}
+git commit -m "{type}({scope}): {description}
+
+- {bullet 1}
+- {bullet 2}"
+git push origin main
+git branch -d feature/X-Y-{name}
+git push origin --delete feature/X-Y-{name}
+\`\`\`
+
+**Checklist:**
+- [ ] All subtasks complete
+- [ ] All verification passes
+- [ ] Squash merged to main
+- [ ] Feature branch deleted
+```
+
+### Project Complete Checklist
+
+```markdown
+# Project Complete Checklist
+
+- [ ] Phase 0: Setup complete
+- [ ] Phase 1: Core complete
+- [ ] Phase 2: Polish complete
+- [ ] All tests pass
+- [ ] Coverage meets target
+- [ ] CLI/API/App works end-to-end
+- [ ] Clean git history (squash merges only)
+```
+
+---
+
+## Project Type Scaffolds
+
+### CLI Tool
+
+**Typical Phase Structure:**
+- Phase 0: Project setup (pyproject.toml/package.json, directory structure, tooling)
+- Phase 1: Core CLI (argument parsing, main commands, output formatting)
+- Phase 2: Testing & polish (edge cases, error handling, end-to-end verification)
+
+**Python CLI Stack:**
+| Component | Technology |
+|-----------|------------|
+| Language | Python 3.11+ |
+| CLI Framework | Click |
+| Output | Rich |
+| Testing | pytest + pytest-cov |
+| Linting | ruff |
+| Types | mypy (strict) |
+| Build | hatchling or setuptools |
+
+**TypeScript CLI Stack:**
+| Component | Technology |
+|-----------|------------|
+| Language | TypeScript 5+ |
+| CLI Framework | Commander or yargs |
+| Output | chalk + ora |
+| Testing | vitest or jest |
+| Linting | eslint + prettier |
+| Build | tsup or esbuild |
+
+**Directory Structure (Python):**
+```
+{project}/
+├── src/{package}/
+│   ├── __init__.py
+│   ├── cli.py
+│   └── {modules}.py
+├── tests/
+│   ├── __init__.py
+│   └── test_{modules}.py
+├── pyproject.toml
+├── CLAUDE.md
+├── PROJECT_BRIEF.md
+└── DEVELOPMENT_PLAN.md
+```
+
+**Directory Structure (TypeScript):**
+```
+{project}/
+├── src/
+│   ├── index.ts
+│   ├── cli.ts
+│   └── {modules}.ts
+├── tests/
+│   └── {modules}.test.ts
+├── package.json
+├── tsconfig.json
+├── CLAUDE.md
+├── PROJECT_BRIEF.md
+└── DEVELOPMENT_PLAN.md
+```
+
+### Web Application
+
+**Typical Phase Structure:**
+- Phase 0: Project setup (framework init, DB schema, auth scaffold)
+- Phase 1: Backend (API routes, business logic, data layer)
+- Phase 2: Frontend (pages, components, forms)
+- Phase 3: Integration & polish (E2E tests, error handling, deployment)
+
+**Full-Stack Stack:**
+| Component | Technology |
+|-----------|------------|
+| Frontend | React/Next.js or SvelteKit |
+| Backend | Next.js API routes or FastAPI |
+| Database | PostgreSQL + Prisma/SQLAlchemy |
+| Auth | NextAuth or session-based |
+| Testing | vitest + Playwright |
+| Styling | Tailwind CSS |
+
+**Directory Structure (Next.js):**
+```
+{project}/
+├── src/
+│   ├── app/
+│   │   ├── layout.tsx
+│   │   ├── page.tsx
+│   │   └── api/
+│   ├── components/
+│   ├── lib/
+│   └── types/
+├── tests/
+├── prisma/
+│   └── schema.prisma
+├── package.json
+├── tsconfig.json
+├── tailwind.config.ts
+└── CLAUDE.md
+```
+
+**Directory Structure (FastAPI + React):**
+```
+{project}/
+├── backend/
+│   ├── app/
+│   │   ├── __init__.py
+│   │   ├── main.py
+│   │   ├── models.py
+│   │   └── routes/
+│   └── tests/
+├── frontend/
+│   ├── src/
+│   └── package.json
+├── docker-compose.yml
+└── CLAUDE.md
+```
+
+### REST API
+
+**Typical Phase Structure:**
+- Phase 0: Project setup (framework, DB, schema definitions)
+- Phase 1: Data models & migrations
+- Phase 2: API endpoints (CRUD, auth, validation)
+- Phase 3: Testing & documentation (integration tests, OpenAPI docs)
+
+**Python API Stack:**
+| Component | Technology |
+|-----------|------------|
+| Framework | FastAPI |
+| ORM | SQLAlchemy 2.0 or SQLModel |
+| Database | PostgreSQL or SQLite |
+| Validation | Pydantic v2 |
+| Testing | pytest + httpx |
+| Docs | Auto OpenAPI |
+
+**TypeScript API Stack:**
+| Component | Technology |
+|-----------|------------|
+| Framework | Express or Hono |
+| ORM | Prisma or Drizzle |
+| Validation | Zod |
+| Testing | vitest + supertest |
+
+**Directory Structure (FastAPI):**
+```
+{project}/
+├── src/{package}/
+│   ├── __init__.py
+│   ├── main.py
+│   ├── config.py
+│   ├── models/
+│   ├── routes/
+│   ├── services/
+│   └── middleware/
+├── tests/
+│   ├── conftest.py
+│   ├── test_routes/
+│   └── test_services/
+├── alembic/
+├── pyproject.toml
+└── CLAUDE.md
+```
+
+### Library / Package
+
+**Typical Phase Structure:**
+- Phase 0: Project setup (build config, CI, docs scaffold)
+- Phase 1: Core API (public interface, main functionality)
+- Phase 2: Extended features (edge cases, performance, advanced API)
+- Phase 3: Documentation & publishing (README, API docs, examples)
+
+**Python Library Stack:**
+| Component | Technology |
+|-----------|------------|
+| Build | hatchling or setuptools |
+| Testing | pytest + hypothesis |
+| Docs | mkdocs-material or Sphinx |
+| Types | mypy strict + py.typed marker |
+
+**TypeScript Library Stack:**
+| Component | Technology |
+|-----------|------------|
+| Build | tsup (dual CJS/ESM) |
+| Testing | vitest |
+| Docs | typedoc |
+| Types | strict tsconfig |
+
+**Directory Structure (Python):**
+```
+{project}/
+├── src/{package}/
+│   ├── __init__.py   (public API exports)
+│   ├── py.typed      (PEP 561 marker)
+│   └── {modules}.py
+├── tests/
+├── docs/
+├── examples/
+├── pyproject.toml
+└── CLAUDE.md
+```
+
+---
+
+## CLAUDE.md Template
+
+```markdown
+# {Project} - Claude Code Rules
+
+## Project Overview
+{One paragraph: what it is, what it does, who it's for}
+
+## Quick Reference
+
+| Component | Technology |
+|-----------|------------|
+| Language | {language} |
+| Framework | {framework} |
+| Testing | {test framework} |
+| Linting | {linter} |
+
+## Directory Structure
+\`\`\`
+{actual directory tree}
+\`\`\`
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `{install}` | Install dependencies |
+| `{test}` | Run tests |
+| `{lint}` | Run linter |
+| `{typecheck}` | Type check |
+| `{build}` | Build for production |
+
+## Coding Standards
+
+- {Standard 1: e.g., "All functions have type annotations"}
+- {Standard 2: e.g., "Test files mirror src structure: src/foo.py → tests/test_foo.py"}
+- {Standard 3: e.g., "No default exports in TypeScript"}
+
+## Session Checklist
+
+### Starting a Session
+- [ ] Read this file
+- [ ] Check DEVELOPMENT_PLAN.md for next subtask
+- [ ] Create/checkout correct branch: `git checkout -b feature/X-Y-name`
+
+### Completing a Subtask
+- [ ] All deliverables implemented
+- [ ] All tests pass: `{test command}`
+- [ ] Lint passes: `{lint command}`
+- [ ] Types pass: `{typecheck command}`
+- [ ] Commit: `git add -A && git commit -m "{type}({scope}): {description}"`
+- [ ] Update completion notes in DEVELOPMENT_PLAN.md
+
+### Completing a Task (Squash Merge)
+- [ ] All subtasks complete
+- [ ] `git checkout main && git merge --squash feature/X-Y-name`
+- [ ] `git commit -m "{type}({scope}): {summary}"`
+- [ ] `git branch -d feature/X-Y-name`
+
+## Error Recovery
+
+- If tests fail: fix before continuing to next deliverable
+- If blocked: document in completion notes, move to next deliverable
+- If unclear: check this file for conventions, then PROJECT_BRIEF.md for requirements
+```
+
+---
+
+## PowerShell / Non-Python Projects
+
+When the brief specifies PowerShell or another non-Python/non-TypeScript stack,
+completely rewrite the scaffold to match:
+
+- **.ps1** scripts and **.psm1** modules instead of .py files
+- **Pester** for testing instead of pytest
+- **PSScriptAnalyzer** for linting
+- **M365/Azure PowerShell modules** where applicable
+- Use `Invoke-Pester` for verification commands
+
+Do NOT default to Python when the brief specifies otherwise.

--- a/skills/devplan/references/validation.md
+++ b/skills/devplan/references/validation.md
@@ -1,0 +1,255 @@
+# DevPlan Validation Rules
+
+Two levels of validation: **structural** (does the plan have the right sections?)
+and **Haiku-executable** (can Haiku execute it mechanically?).
+
+---
+
+## Structural Validation
+
+Check that the plan contains all required sections. Report each as PASS/FAIL.
+
+### Required Sections
+
+| Section | Check |
+|---------|-------|
+| Project Summary | Has name, goal, phase/task/subtask counts |
+| Phase Overview | Table with phase names, task counts, status |
+| At least one Phase | `# Phase N:` heading exists |
+| At least one Task | `## Task N.N:` heading exists |
+| At least one Subtask | `**Subtask N.N.N:` bold marker exists |
+| Git workflow | Squash merge instructions per task |
+| Project Complete | Final checklist at end |
+
+### Per-Subtask Required Sections
+
+Each `**Subtask X.Y.Z:**` must contain:
+
+| Section | Check |
+|---------|-------|
+| Prerequisites | Lists prior subtask dependencies |
+| Deliverables | Checkboxed list of file paths |
+| Complete Code | At least one fenced code block |
+| Verification | Bash commands with expected output |
+| Success Criteria | Checkboxed list of testable conditions |
+| Completion Notes | Template fields for executor to fill |
+
+### Per-Task Required Sections
+
+Each `## Task X.Y:` must contain:
+
+| Section | Check |
+|---------|-------|
+| Branch name | `**Branch:** \`feature/X-Y-name\`` |
+| Squash merge | Commands for merge, commit, branch delete |
+| Task checklist | All subtasks listed + verification + merge checks |
+
+### Structural Validation Script
+
+To validate structure, grep for these markers:
+
+```bash
+# Phase count
+grep -c '^# Phase' DEVELOPMENT_PLAN.md
+
+# Task count
+grep -c '^## Task' DEVELOPMENT_PLAN.md
+
+# Subtask count (bold format only — headings don't count!)
+grep -c '^\*\*Subtask [0-9]' DEVELOPMENT_PLAN.md
+
+# Check each subtask has required sections
+for id in $(grep -oP '(?<=\*\*Subtask )[0-9]+\.[0-9]+\.[0-9]+' DEVELOPMENT_PLAN.md); do
+  echo "=== Subtask $id ==="
+  # These should all return matches:
+  grep -c "Prerequisites" DEVELOPMENT_PLAN.md
+  grep -c "Deliverables" DEVELOPMENT_PLAN.md
+  grep -c "Verification" DEVELOPMENT_PLAN.md
+  grep -c "Success Criteria" DEVELOPMENT_PLAN.md
+  grep -c "Completion Notes" DEVELOPMENT_PLAN.md
+done
+```
+
+---
+
+## Haiku-Executability Validation
+
+The harder check. A plan is Haiku-executable when Claude Haiku can implement
+every subtask by mechanically following the instructions — no inference, no
+context from other subtasks, no domain knowledge required.
+
+### Code Block Rules
+
+1. **Every deliverable file MUST have a complete code block**
+   - FAIL: "Create `src/config.py` with the configuration class"
+   - PASS: "Create `src/config.py`:" followed by complete code in a fenced block
+
+2. **All imports must be present in every code block**
+   - FAIL: Code that assumes imports from a previous subtask
+   - PASS: Every file's code block starts with all necessary imports
+
+3. **No placeholders or TODOs**
+   - FAIL: `{placeholder}`, `// TODO`, `# implement this`, `pass  # fill in later`
+   - PASS: Working code that does what it claims
+   - Verification: `grep -rn 'TODO\|FIXME\|placeholder\|fill in\|implement this'`
+
+4. **No "Add to existing file" without context**
+   - FAIL: "Add this method to `src/app.py`"
+   - PASS: Either show the complete file, OR show the exact insertion point with
+     surrounding lines for context (before/after blocks)
+
+5. **File paths must be explicit**
+   - FAIL: "Create the model file"
+   - PASS: "Create file `src/models/user.py`:"
+
+### Verification Rules
+
+1. **Every subtask has verification commands**
+   - Must be bash commands that can be copy-pasted
+   - Must include expected output as comments
+
+2. **Verification must prove the code works, not just exists**
+   - FAIL: `ls src/config.py` (proves file exists, not that it works)
+   - PASS: `python -c "from config import Config; print(Config().base_url)"` + expected output
+
+3. **Test verification must show pass count**
+   - FAIL: `pytest` (no expected output)
+   - PASS: `pytest tests/ -v` + `# Expected: X passed`
+
+### Self-Containment Rules
+
+1. **Each subtask is independently executable**
+   - Haiku will not remember instructions from the plan header or other subtasks
+   - If a subtask needs git commands, include them explicitly
+   - If a subtask needs to run tests, include the full command
+
+2. **Test files must be self-contained**
+   - All fixtures defined in the test file or conftest.py (which must be a deliverable)
+   - No references to external test data without creating it
+   - Mock objects must match production interfaces exactly
+
+3. **Dependencies between subtasks use prerequisites only**
+   - Prerequisites list which subtasks must be done first
+   - But the subtask itself must not require reading the prior subtask's code blocks
+
+---
+
+## Battle-Tested Rules (From Production Failures)
+
+These rules come from real failures in production plan execution. Each one caused
+a plan to fail when executed by Haiku. Treat them as hard requirements.
+
+### CRITICAL: Implicit Instructions Not Repeated Per-Subtask
+
+**Failure**: Haiku agent does not remember instructions from earlier in the
+document. A plan said "always run tests after each subtask" in the header,
+but Haiku only read the individual subtask and never saw that instruction.
+
+**Rule**: Include ALL required commands (git, checkpoints, verification)
+explicitly in EVERY task completion section. Never say "do X" once at the
+top and expect it to be remembered.
+
+### CRITICAL: Large File Editing Without Chunked Strategy
+
+**Failure**: Executor tried to read a 17,000-line file into context, exceeded
+the context window, and couldn't make targeted edits.
+
+**Rule**: For files over 500 lines, subtasks must include a Large File Protocol:
+1. NEVER read the entire file — use grep to find target sections
+2. Read with offset/limit to view 50-100 line chunks
+3. Edit for surgical changes only
+4. Verify edits with targeted grep after each change
+5. For bulk changes, process in batches of 5-10 matches
+
+### CRITICAL: App State Contract Mismatch
+
+**Failure**: Auth middleware read `app.state` attributes that were never set
+in `lifespan()`, causing every authenticated request to crash at runtime.
+
+**Rule**: Every subtask that reads shared state (app.state, context, globals)
+must also verify/update the initialization code. Add an integration test that
+actually starts the app and hits the endpoint.
+
+### CRITICAL: TODO Stubs in Critical Code
+
+**Failure**: Pipeline orchestrator left TODO stubs for audit logging, redaction,
+and response DLP — the three most critical features. Tests passed because they
+only checked the skeleton.
+
+**Rule**: Split large subtasks rather than leaving stubs. Verification MUST
+include `grep -rn 'TODO\|FIXME' src/` and fail if any remain.
+
+### WARNING: Test Mock Interface Drift
+
+**Failure**: Test mocks used different field names than production Pydantic
+models. Tests passed with wrong assertions while production code would crash.
+
+**Rule**: Test mocks must either inherit from the real model class or use
+`model_construct()`. Never hand-write mock dataclasses for Pydantic models.
+
+### WARNING: Haiku Validator 0-Subtask Pass
+
+**Failure**: Validator reported PASS but "Subtasks Checked: 0" because the
+plan used `### Task X.Y` headings instead of `**Subtask X.Y.Z:**` bold markers.
+
+**Rule**: Always use `**Subtask X.Y.Z: Title**` format (bold, three-level ID).
+After validation, confirm the subtask count is > 0. A pass with 0 checks is
+a false positive.
+
+### WARNING: Generic Scaffold Shipped as Plan
+
+**Failure**: A scaffold with placeholder text and empty code blocks was treated
+as a finished plan. Haiku executed it and produced empty files.
+
+**Rule**: The scaffold from `devplan plan` is a starting point only. You MUST
+enhance it with complete, project-specific code before it's Haiku-executable.
+Study the HelloCLI example in `examples/hello-cli-plan.md` for the quality bar.
+
+### WARNING: Python Scaffold for Non-Python Project
+
+**Failure**: Plan generated Python/Click patterns for a project that specified
+PowerShell as the primary language.
+
+**Rule**: Match the tech stack to what the brief specifies. If the brief says
+PowerShell, use .ps1/.psm1/Pester. If it says Rust, use Cargo/clippy. Never
+default to Python.
+
+---
+
+## Validation Checklist (Copy-Paste for Quick Check)
+
+```markdown
+## Plan Validation Results
+
+### Structural
+- [ ] Project Summary table present
+- [ ] Phase Overview table present
+- [ ] Subtask count matches plan: expected {N}, found {N}
+- [ ] All subtasks have Prerequisites section
+- [ ] All subtasks have Deliverables section
+- [ ] All subtasks have Complete Code section
+- [ ] All subtasks have Verification section
+- [ ] All subtasks have Success Criteria section
+- [ ] All subtasks have Completion Notes template
+- [ ] All tasks have Branch name
+- [ ] All tasks have Squash Merge section
+- [ ] Project Complete checklist present
+
+### Haiku-Executability
+- [ ] All deliverable files have complete code blocks
+- [ ] All code blocks include imports
+- [ ] No TODO/FIXME/placeholder text found
+- [ ] All verification commands have expected output
+- [ ] Each subtask is self-contained (no implicit dependencies)
+- [ ] Test files are self-contained (fixtures included)
+- [ ] Large file edits use chunked strategy
+- [ ] Subtask headings use **Subtask X.Y.Z:** format
+- [ ] Tech stack matches what brief specifies
+
+### Counts
+- Phases: {N}
+- Tasks: {N}
+- Subtasks: {N}
+- Code blocks: {N}
+- Verification blocks: {N}
+```

--- a/skills/devplan/references/workflows.md
+++ b/skills/devplan/references/workflows.md
@@ -1,0 +1,261 @@
+# DevPlan Workflow Exports
+
+Formats for exporting a DEVELOPMENT_PLAN.md as visual diagrams.
+
+---
+
+## Progress Summary
+
+Parse the plan to generate a completion summary. Check checkbox states
+(`[x]` vs `[ ]`) across all subtask deliverables and success criteria.
+
+### Output Format
+
+```markdown
+# Progress Summary: {Project}
+
+## Overall: {completed}/{total} subtasks ({percentage}%)
+
+| Phase | Name | Progress | Status |
+|-------|------|----------|--------|
+| 0 | Setup | 3/3 (100%) | Complete |
+| 1 | Core | 2/5 (40%) | In Progress |
+| 2 | Polish | 0/4 (0%) | Pending |
+
+## Next Actionable Subtask
+**Subtask 1.2.3: {Title}**
+Prerequisites: All met
+Branch: `feature/1-2-name`
+
+## Recently Completed
+- [x] 1.2.2: {Title} — {completion notes summary}
+- [x] 1.2.1: {Title} — {completion notes summary}
+```
+
+### Parsing Logic
+
+```bash
+# Count total subtasks
+total=$(grep -c '^\*\*Subtask [0-9]' DEVELOPMENT_PLAN.md)
+
+# Count completed subtasks (all deliverable checkboxes checked)
+# A subtask is complete when its Completion Notes have been filled in
+completed=$(grep -c 'Implementation.*:.*[A-Za-z]' DEVELOPMENT_PLAN.md)
+
+# Percentage
+echo "Progress: $completed / $total"
+```
+
+---
+
+## Mermaid Export
+
+Generate a Mermaid flowchart from the plan structure. Useful for embedding
+in GitHub READMEs, documentation, or viewing in VS Code.
+
+### Format
+
+```mermaid
+flowchart TD
+    subgraph Phase0["Phase 0: Project Setup"]
+        T0_1["Task 0.1: Init Structure"]
+        S0_1_1["0.1.1: pyproject.toml ✅"]
+        S0_1_2["0.1.2: Package layout ✅"]
+        T0_1 --> S0_1_1 --> S0_1_2
+
+        T0_2["Task 0.2: Install & Verify"]
+        S0_2_1["0.2.1: Dev dependencies ✅"]
+        T0_2 --> S0_2_1
+    end
+
+    subgraph Phase1["Phase 1: Core Implementation"]
+        T1_1["Task 1.1: Main Feature"]
+        S1_1_1["1.1.1: Core logic ⏳"]
+        S1_1_2["1.1.2: Tests 🔲"]
+        T1_1 --> S1_1_1 --> S1_1_2
+    end
+
+    Phase0 --> Phase1
+
+    classDef completed fill:#10b981,stroke:#059669,color:#fff
+    classDef inprogress fill:#f59e0b,stroke:#d97706,color:#fff
+    classDef pending fill:#6b7280,stroke:#4b5563,color:#fff
+
+    class S0_1_1,S0_1_2,S0_2_1 completed
+    class S1_1_1 inprogress
+    class S1_1_2 pending
+```
+
+### Generation Rules
+
+1. Create a `subgraph` for each Phase
+2. Create nodes for each Task and Subtask within the phase
+3. Connect subtasks sequentially within their task
+4. Connect phases sequentially
+5. Apply status classes:
+   - `completed` (green): All deliverable checkboxes are `[x]`
+   - `inprogress` (amber): Some checkboxes are `[x]`, some `[ ]`
+   - `pending` (gray): All checkboxes are `[ ]`
+6. Use status icons: `completed`, `inprogress`, `pending`
+
+### Node ID Convention
+
+- Phases: `Phase{N}`
+- Tasks: `T{phase}_{task}` (e.g., `T1_2`)
+- Subtasks: `S{phase}_{task}_{sub}` (e.g., `S1_2_3`)
+
+### Output
+
+Write the Mermaid diagram to `workflow.md`:
+
+```markdown
+# {Project} — Development Workflow
+
+\`\`\`mermaid
+{generated diagram}
+\`\`\`
+
+Generated from DEVELOPMENT_PLAN.md on {date}.
+```
+
+---
+
+## ReactFlow Export
+
+Generate JSON compatible with ReactFlow for interactive visualization
+in tools like Sim.ai or custom React dashboards.
+
+### Node Schema
+
+```json
+{
+  "nodes": [
+    {
+      "id": "phase-0",
+      "type": "group",
+      "data": {
+        "label": "Phase 0: Project Setup",
+        "status": "completed"
+      },
+      "position": { "x": 0, "y": 0 },
+      "style": { "width": 400, "height": 300 }
+    },
+    {
+      "id": "task-0-1",
+      "type": "default",
+      "data": {
+        "label": "Task 0.1: Init Structure",
+        "status": "completed",
+        "branch": "feature/0-1-init-structure"
+      },
+      "position": { "x": 50, "y": 50 },
+      "parentId": "phase-0"
+    },
+    {
+      "id": "subtask-0-1-1",
+      "type": "default",
+      "data": {
+        "label": "0.1.1: pyproject.toml",
+        "status": "completed",
+        "deliverables": 3,
+        "deliverables_done": 3
+      },
+      "position": { "x": 50, "y": 120 },
+      "parentId": "phase-0"
+    }
+  ],
+  "edges": [
+    {
+      "id": "e-t01-s011",
+      "source": "task-0-1",
+      "target": "subtask-0-1-1",
+      "type": "smoothstep"
+    },
+    {
+      "id": "e-s011-s012",
+      "source": "subtask-0-1-1",
+      "target": "subtask-0-1-2",
+      "type": "smoothstep"
+    },
+    {
+      "id": "e-phase0-phase1",
+      "source": "phase-0",
+      "target": "phase-1",
+      "type": "smoothstep",
+      "style": { "strokeWidth": 3 }
+    }
+  ]
+}
+```
+
+### Status Colors
+
+| Status | Background | Border |
+|--------|-----------|--------|
+| completed | #10b981 | #059669 |
+| in_progress | #f59e0b | #d97706 |
+| pending | #e5e7eb | #d1d5db |
+| blocked | #ef4444 | #dc2626 |
+
+### Layout Algorithm
+
+1. Phases flow top-to-bottom, spaced 400px vertically
+2. Tasks within a phase flow left-to-right, spaced 250px
+3. Subtasks within a task flow top-to-bottom, spaced 80px
+4. Group nodes (phases) auto-size to contain children with 40px padding
+
+---
+
+## GitHub Issue to Remediation Plan
+
+Convert a GitHub issue into a remediation task that follows the same plan format.
+
+### Input
+
+Fetch with: `gh issue view <number> --json number,title,body,labels,comments,url`
+
+### Output Structure
+
+```markdown
+# Remediation: {issue title} (#{number})
+
+**Source**: {issue URL}
+**Priority**: {from labels or P2 default}
+
+## Task R.1: {Fix Description}
+
+**Branch:** `fix/{number}-{slug}`
+
+**Subtask R.1.1: {Specific Fix}**
+
+**Prerequisites:** None
+
+**Deliverables:**
+- [ ] {file to fix}
+- [ ] {test to add}
+
+**Complete Code:**
+{complete fix code}
+
+**Verification:**
+{commands proving the fix works}
+
+**Success Criteria:**
+- [ ] Issue scenario no longer reproduces
+- [ ] Regression test passes
+- [ ] No existing tests broken
+
+### Task R.1 Complete - Squash Merge
+
+\`\`\`bash
+git checkout main && git merge --squash fix/{number}-{slug}
+git commit -m "fix({scope}): {description}
+
+Closes #{number}"
+\`\`\`
+```
+
+### Remediation ID Convention
+
+Use `R.X` prefix for remediation tasks to distinguish from plan tasks.
+If appending to an existing plan, find the highest existing R.X and increment.

--- a/skills/devplan/scripts/check-haiku.sh
+++ b/skills/devplan/scripts/check-haiku.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Haiku-executability checker for DEVELOPMENT_PLAN.md
+# Checks that every subtask has complete, copy-pasteable code.
+# Usage: bash check-haiku.sh [path/to/DEVELOPMENT_PLAN.md]
+
+set -uo pipefail
+
+PLAN="${1:-DEVELOPMENT_PLAN.md}"
+ERRORS=0
+WARNINGS=0
+CHECKED=0
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+if [[ ! -f "$PLAN" ]]; then
+  echo "FAIL: $PLAN not found"
+  exit 1
+fi
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; ERRORS=$((ERRORS + 1)); }
+warn() { echo "  WARN: $1"; WARNINGS=$((WARNINGS + 1)); }
+
+echo "=== Haiku-Executability Check: $PLAN ==="
+echo ""
+
+SUBTASK_IDS=$(grep -oP '(?<=\*\*Subtask )[0-9]+\.[0-9]+\.[0-9]+' "$PLAN" 2>/dev/null || true)
+
+if [[ -z "$SUBTASK_IDS" ]]; then
+  fail "No subtasks found (must use **Subtask X.Y.Z:** format, not ### heading format)"
+  echo ""
+  echo "=== Results ==="
+  echo "  Subtasks checked: 0"
+  echo "  VERDICT: FAIL (nothing to validate)"
+  exit 1
+fi
+
+for sid in $SUBTASK_IDS; do
+  CHECKED=$((CHECKED + 1))
+  echo "--- Subtask $sid ---"
+
+  # Extract subtask block to temp file
+  BLOCK_FILE="$TMPDIR/block_$sid"
+  sed -n "/\*\*Subtask $sid/,/\(\*\*Subtask [0-9]\|^## Task\|^# Phase\|^# Project\)/p" "$PLAN" > "$BLOCK_FILE" 2>/dev/null || true
+
+  # Check for file path references in deliverables
+  FILE_COUNT=$(grep -oP '`[a-zA-Z0-9_./-]+\.[a-zA-Z]+`' "$BLOCK_FILE" 2>/dev/null | sort -u | wc -l | tr -d ' ')
+
+  if [[ "$FILE_COUNT" -gt 0 ]]; then
+    pass "$sid: $FILE_COUNT file references found"
+  else
+    warn "$sid: No file path references in deliverables"
+  fi
+
+  # Check for code blocks
+  FENCE_COUNT=$(grep -c '```' "$BLOCK_FILE" 2>/dev/null || true)
+  FENCE_COUNT=${FENCE_COUNT:-0}
+  CODE_BLOCK_COUNT=$((FENCE_COUNT / 2))
+
+  if [[ "$CODE_BLOCK_COUNT" -gt 0 ]]; then
+    pass "$sid: $CODE_BLOCK_COUNT code blocks"
+  else
+    fail "$sid: No code blocks found — NOT Haiku-executable"
+  fi
+
+  # Extract code block content to temp file
+  CODE_FILE="$TMPDIR/code_$sid"
+  sed -n '/^```/,/^```/p' "$BLOCK_FILE" > "$CODE_FILE" 2>/dev/null || true
+
+  # Check for placeholder patterns in code blocks
+  PH_COUNT=$(grep -ciE '\{placeholder\}|# ?TODO|// ?TODO|# implement|// implement|\.\.\..*implement' "$CODE_FILE" 2>/dev/null || true)
+  PH_COUNT=${PH_COUNT:-0}
+  PASS_COUNT=$(grep -cE '^\s*pass\s*$' "$CODE_FILE" 2>/dev/null || true)
+  PASS_COUNT=${PASS_COUNT:-0}
+  TOTAL_PH=$((PH_COUNT + PASS_COUNT))
+
+  if [[ "$TOTAL_PH" -eq 0 ]]; then
+    pass "$sid: No placeholders in code"
+  else
+    fail "$sid: Found $TOTAL_PH placeholder/TODO patterns in code blocks"
+  fi
+
+  # Check for import statements (language-agnostic)
+  IMPORT_COUNT=$(grep -ciE '^import |^from .+ import|^const .+ = require|^use |^#include' "$CODE_FILE" 2>/dev/null || true)
+  IMPORT_COUNT=${IMPORT_COUNT:-0}
+
+  if [[ "$CODE_BLOCK_COUNT" -gt 0 && "$IMPORT_COUNT" -eq 0 ]]; then
+    warn "$sid: Code blocks have no import statements (may be config files — verify manually)"
+  fi
+
+  # Check for verification section with expected output
+  EXPECTED_COUNT=$(grep -c '# Expected' "$BLOCK_FILE" 2>/dev/null || true)
+  EXPECTED_COUNT=${EXPECTED_COUNT:-0}
+
+  if [[ "$EXPECTED_COUNT" -gt 0 ]]; then
+    pass "$sid: Verification has expected output ($EXPECTED_COUNT)"
+  else
+    warn "$sid: Verification commands may be missing expected output comments"
+  fi
+
+  echo ""
+done
+
+echo "=== Results ==="
+echo "  Subtasks checked: $CHECKED"
+echo "  Errors: $ERRORS"
+echo "  Warnings: $WARNINGS"
+
+if [[ "$CHECKED" -eq 0 ]]; then
+  echo "  VERDICT: FAIL (0 subtasks checked — wrong heading format?)"
+  exit 1
+elif [[ "$ERRORS" -gt 0 ]]; then
+  echo "  VERDICT: FAIL ($ERRORS errors)"
+  exit 1
+elif [[ "$WARNINGS" -gt 0 ]]; then
+  echo "  VERDICT: PASS (with $WARNINGS warnings)"
+  exit 0
+else
+  echo "  VERDICT: PASS"
+  exit 0
+fi

--- a/skills/devplan/scripts/validate-plan.sh
+++ b/skills/devplan/scripts/validate-plan.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Structural validation for DEVELOPMENT_PLAN.md
+# Usage: bash validate-plan.sh [path/to/DEVELOPMENT_PLAN.md]
+
+set -uo pipefail
+
+PLAN="${1:-DEVELOPMENT_PLAN.md}"
+ERRORS=0
+WARNINGS=0
+
+if [[ ! -f "$PLAN" ]]; then
+  echo "FAIL: $PLAN not found"
+  exit 1
+fi
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1"; ERRORS=$((ERRORS + 1)); }
+warn() { echo "  WARN: $1"; WARNINGS=$((WARNINGS + 1)); }
+
+echo "=== Structural Validation: $PLAN ==="
+echo ""
+
+# Header checks
+echo "--- Header ---"
+grep -q '^# DEVELOPMENT_PLAN' "$PLAN" && pass "Plan title present" || fail "Missing plan title"
+grep -q 'Haiku-Executable' "$PLAN" && pass "Haiku-executable marker" || warn "Missing Haiku-executable marker"
+grep -q '## Project Summary' "$PLAN" && pass "Project Summary section" || fail "Missing Project Summary"
+grep -q '## Phase Overview' "$PLAN" && pass "Phase Overview section" || fail "Missing Phase Overview"
+
+echo ""
+echo "--- Counts ---"
+
+PHASES=$(grep -c '^# Phase' "$PLAN" 2>/dev/null || echo 0)
+TASKS=$(grep -c '^## Task' "$PLAN" 2>/dev/null || echo 0)
+SUBTASKS=$(grep -c '^\*\*Subtask [0-9]' "$PLAN" 2>/dev/null || echo 0)
+CODE_BLOCKS=$(grep -c '^```' "$PLAN" 2>/dev/null || echo 0)
+CODE_BLOCKS=$((CODE_BLOCKS / 2))
+
+echo "  Phases: $PHASES"
+echo "  Tasks: $TASKS"
+echo "  Subtasks: $SUBTASKS"
+echo "  Code blocks: $CODE_BLOCKS"
+
+[[ "$PHASES" -gt 0 ]] && pass "At least one phase" || fail "No phases found"
+[[ "$TASKS" -gt 0 ]] && pass "At least one task" || fail "No tasks found"
+[[ "$SUBTASKS" -gt 0 ]] && pass "At least one subtask" || fail "No subtasks found (use **Subtask X.Y.Z:** format)"
+
+echo ""
+echo "--- Per-Subtask Checks ---"
+
+SUBTASK_IDS=$(grep -oP '(?<=\*\*Subtask )[0-9]+\.[0-9]+\.[0-9]+' "$PLAN" 2>/dev/null || true)
+
+for sid in $SUBTASK_IDS; do
+  # Extract subtask block (from **Subtask X.Y.Z to next **Subtask or ## Task or # Phase)
+  HAS_DELIVERABLES=$(sed -n "/\*\*Subtask $sid/,/\(\*\*Subtask [0-9]\|^## Task\|^# Phase\|^# Project\)/p" "$PLAN" | grep -c 'Deliverables' 2>/dev/null || echo 0)
+  HAS_CODE=$(sed -n "/\*\*Subtask $sid/,/\(\*\*Subtask [0-9]\|^## Task\|^# Phase\|^# Project\)/p" "$PLAN" | grep -c '```' 2>/dev/null || echo 0)
+  HAS_VERIFY=$(sed -n "/\*\*Subtask $sid/,/\(\*\*Subtask [0-9]\|^## Task\|^# Phase\|^# Project\)/p" "$PLAN" | grep -c 'Verification' 2>/dev/null || echo 0)
+  HAS_SUCCESS=$(sed -n "/\*\*Subtask $sid/,/\(\*\*Subtask [0-9]\|^## Task\|^# Phase\|^# Project\)/p" "$PLAN" | grep -c 'Success Criteria' 2>/dev/null || echo 0)
+  HAS_NOTES=$(sed -n "/\*\*Subtask $sid/,/\(\*\*Subtask [0-9]\|^## Task\|^# Phase\|^# Project\)/p" "$PLAN" | grep -c 'Completion Notes' 2>/dev/null || echo 0)
+
+  ISSUES=""
+  [[ "$HAS_DELIVERABLES" -eq 0 ]] && ISSUES="$ISSUES deliverables"
+  [[ "$HAS_CODE" -lt 2 ]] && ISSUES="$ISSUES code-blocks"
+  [[ "$HAS_VERIFY" -eq 0 ]] && ISSUES="$ISSUES verification"
+  [[ "$HAS_SUCCESS" -eq 0 ]] && ISSUES="$ISSUES success-criteria"
+  [[ "$HAS_NOTES" -eq 0 ]] && ISSUES="$ISSUES completion-notes"
+
+  if [[ -z "$ISSUES" ]]; then
+    pass "Subtask $sid: all sections present"
+  else
+    fail "Subtask $sid: missing:$ISSUES"
+  fi
+done
+
+echo ""
+echo "--- Quality Checks ---"
+
+# Check for TODOs in code blocks
+TODOS=$(grep -n 'TODO\|FIXME\|placeholder\|fill in later\|implement this' "$PLAN" 2>/dev/null | grep -v '^#\|Completion Notes\|filled by executor' | wc -l || echo 0)
+[[ "$TODOS" -eq 0 ]] && pass "No TODO/placeholder text in code" || warn "Found $TODOS potential TODO/placeholder lines"
+
+# Check for squash merge sections
+MERGE_SECTIONS=$(grep -c 'Squash Merge' "$PLAN" 2>/dev/null || echo 0)
+[[ "$MERGE_SECTIONS" -ge "$TASKS" ]] && pass "Squash merge sections ($MERGE_SECTIONS >= $TASKS tasks)" || warn "Missing squash merge sections ($MERGE_SECTIONS < $TASKS tasks)"
+
+# Check for project complete checklist
+grep -q 'Project Complete' "$PLAN" && pass "Project Complete checklist" || warn "Missing Project Complete checklist"
+
+echo ""
+echo "=== Results ==="
+echo "  Errors: $ERRORS"
+echo "  Warnings: $WARNINGS"
+
+if [[ "$ERRORS" -gt 0 ]]; then
+  echo "  VERDICT: FAIL"
+  exit 1
+elif [[ "$WARNINGS" -gt 0 ]]; then
+  echo "  VERDICT: PASS (with warnings)"
+  exit 0
+else
+  echo "  VERDICT: PASS"
+  exit 0
+fi


### PR DESCRIPTION
## Summary

- Adds the full DevPlan methodology as a standalone Claude Code skill/plugin
- Zero network dependency — no MCP server, no SSE connections, no timeouts
- Installs at user scope via `/plugin marketplace add` + `/plugin install`

## What's included

- **SKILL.md** (1,142 words) — Core methodology, interview flow, sub-command dispatch
- **references/templates.md** — Brief/plan/CLAUDE.md templates for all 4 project types (CLI, web app, API, library)
- **references/validation.md** — Structure + Haiku-executability rules + all battle-tested lessons baked in as hard rules
- **references/agents.md** — Executor (Haiku) and verifier (Sonnet) agent generation patterns
- **references/workflows.md** — Mermaid/ReactFlow export + progress tracking + issue-to-task
- **scripts/validate-plan.sh** — Standalone structural validation
- **scripts/check-haiku.sh** — Standalone Haiku-executability checker
- **examples/hello-cli-plan.md** — Gold standard reference plan
- **.claude-plugin/plugin.json** — Plugin metadata for discovery
- **README.md** updated with "NEW — Install as a Skill" section at top

## Motivation

The MCP SSE server has reliability issues (connection drops every 300-600s, tools fail to register). A local skill eliminates that fragility entirely. The lessons learned system was intentionally omitted — Nellie supersedes it.

## Test plan

- [ ] `/plugin marketplace add mmorris35/devplan-mcp-server` succeeds
- [ ] `/plugin install devplan@mmorris35 --scope user` succeeds
- [ ] `/devplan` invokes the skill
- [ ] `bash scripts/validate-plan.sh examples/hello-cli-plan.md` passes
- [ ] `bash scripts/check-haiku.sh examples/hello-cli-plan.md` runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)