### PR TITLE
fix: correct marketplace source to ./plugins/devplan

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "devplan",
-      "source": ".",
+      "source": "./plugins/devplan",
       "description": "DevPlan skill — interview, brief, Haiku-executable plans, executor/verifier agents. Runs fully local, no MCP server dependency.",
       "version": "1.0.0"
     }


### PR DESCRIPTION
source was left as '.' after the subdir move. Corrects it so /plugin install devplan@mmorris35 resolves.

Made on [Distiller](https://pamir.ai)